### PR TITLE
Fixed file issues with bazel

### DIFF
--- a/pass/semantic/BUILD
+++ b/pass/semantic/BUILD
@@ -1,0 +1,20 @@
+#  This file is distributed under the BSD 3-Clause License. See LICENSE for details.
+cc_library(
+    name = "semantic_pass",
+    srcs = glob(["*.cpp"],exclude=["*test*.cpp"]),
+    hdrs = glob(["*.hpp"]),
+    visibility = ["//visibility:public"],
+    includes = ["."],
+    deps = [
+        "//core:core",
+        "//elab:elab",
+    ]
+)
+
+cc_test(
+    name = "lnast_semantic_test",
+    srcs = ["tests/lnast_semantic_test.cpp",],
+    deps = [
+        ":semantic_pass",
+        ],
+    )

--- a/pass/semantic/semantic_check.cpp
+++ b/pass/semantic/semantic_check.cpp
@@ -1,0 +1,275 @@
+
+#include "pass.hpp"
+#include "semantic_check.hpp"
+
+bool Semantic_pass::is_primitive_op(const Lnast_ntype node_type) {
+  if (node_type.is_logical_op() || node_type.is_unary_op() || node_type.is_nary_op() || node_type.is_assign() || node_type.is_dp_assign() ||  node_type.is_as() || node_type.is_eq() || node_type.is_select() || node_type.is_bit_select() || node_type.is_logic_shift_right() || node_type.is_arith_shift_right() || node_type.is_arith_shift_left() || node_type.is_rotate_shift_right() || node_type.is_rotate_shift_left() || node_type.is_dynamic_shift_left() || node_type.is_dynamic_shift_right() ||  node_type.is_dot() || node_type.is_tuple()) {
+    return true;
+  } else {
+    return false;
+  }
+}
+
+bool Semantic_pass::is_tree_structs(const Lnast_ntype node_type) {
+  if (node_type.is_stmts() || node_type.is_cstmts() || node_type.is_if() || node_type.is_cond() || node_type.is_uif() || node_type.is_elif() || node_type.is_for() || node_type.is_while() || node_type.is_func_call() || node_type.is_func_def()) {
+    return true;
+  } else {
+    return false;
+  }
+}
+
+void Semantic_pass::check_primitive_ops(Lnast* lnast, const Lnast_nid &lnidx_opr, const Lnast_ntype node_type) {
+  if (!lnast->has_single_child(lnidx_opr)) {
+    // Unary Operations
+    if (node_type.is_assign() || node_type.is_dp_assign() || node_type.is_not() || node_type.is_logical_not() ||  node_type.is_as()) {
+      auto lhs = lnast->get_first_child(lnidx_opr);
+      auto lhs_type = lnast->get_data(lhs).type;
+      auto rhs = lnast->get_sibling_next(lhs);
+      auto rhs_type = lnast->get_data(rhs).type;
+
+      if (!lhs_type.is_ref()) {
+        Pass::error("Unary Operation Error: LHS Node must be Node type 'ref'\n");
+      }
+      if (!rhs_type.is_ref() && !rhs_type.is_const()) {
+        Pass::error("Unary Operation Error: RHS Node must be Node type 'ref' or 'const'\n");
+      }
+    // N-ary Operations (need to add tuple_concat)
+    } else if (node_type.is_dot() || node_type.is_logical_and() || node_type.is_logical_or() || node_type.is_nary_op() || node_type.is_eq() || node_type.is_select() || node_type.is_bit_select() || node_type.is_logic_shift_right() || node_type.is_arith_shift_right() || node_type.is_arith_shift_left() || node_type.is_rotate_shift_right() || node_type.is_rotate_shift_left() || node_type.is_dynamic_shift_right() ||  node_type.is_dynamic_shift_left()) {
+      for (const auto &lnidx_opr_child : lnast->children(lnidx_opr)) {
+        const auto node_type_child = lnast->get_data(lnidx_opr_child).type;
+
+        if (lnidx_opr_child == lnast->get_first_child(lnidx_opr)) {
+          if (!node_type_child.is_ref()) {
+            Pass::error("N-ary Operation Error: LHS Node must be Node type 'ref'\n");
+          }
+          continue;
+        } else if (!node_type_child.is_ref() && !node_type_child.is_const()) {
+          Pass::error("N-ary Operation Error!: RHS Node(s) must be Node type 'ref' or 'const'\n");
+        }
+      }
+    } else if (node_type.is_tuple()) {
+      bool num_of_ref = 0;
+      bool num_of_assign = 0;
+      for (const auto &lnidx_opr_child : lnast->children(lnidx_opr)) {
+        const auto node_type_child = lnast->get_data(lnidx_opr_child).type;
+
+        if (node_type_child.is_ref()) {
+          num_of_ref += 1;
+        } else if (node_type_child.is_assign()) {
+          num_of_assign += 1;
+        }
+      }
+      if (num_of_ref != 1) {
+        Pass::error("Tuple Operation Error: Missing Reference Node\n");
+      } else if (num_of_assign != 2) {
+        Pass::error("Tuple Operation Error: Missing Assign Node(s)\n");
+      }
+    } else {
+      Pass::error("Primitive Operation Error: Not a Valid Node Type\n");
+    }
+  } else {
+    Pass::error("Primitive Operation Error: Requires at least 2 LNAST Nodes (lhs, rhs)\n");
+  }
+}
+
+void Semantic_pass::check_if_op(Lnast* lnast, const Lnast_nid &lnidx_opr) {
+  bool is_cstmts = false;
+  bool is_cond = false;
+  bool is_stmts = false;
+  for (const auto &lnidx_opr_child : lnast->children(lnidx_opr)) {
+    const auto ntype_child = lnast->get_data(lnidx_opr_child).type;
+
+    if (ntype_child.is_cstmts() || ntype_child.is_stmts()) {
+      if (ntype_child.is_cstmts()) {
+        is_cstmts = true;
+      } else {
+        is_stmts = true;
+      }
+
+      for (const auto &lnidx_opr_child_child : lnast->children(lnidx_opr_child)) {
+        const auto ntype_child_child = lnast->get_data(lnidx_opr_child_child).type;
+
+        if (is_primitive_op(ntype_child_child)) {
+          check_primitive_ops(lnast, lnidx_opr_child_child, ntype_child_child);
+        } else if (is_tree_structs(ntype_child_child)) {
+          check_if_op(lnast, lnidx_opr_child_child);
+        }
+      }
+    } else if (ntype_child.is_cond()) {
+      if (lnast->has_single_child(lnidx_opr_child)) {
+        is_cond = true;
+        const auto  lnidx_opr_child_child = lnast->get_first_child(lnidx_opr_child);
+        const auto ntype_child_child = lnast->get_data(lnidx_opr_child_child).type;
+        if (!ntype_child_child.is_ref()) {
+          Pass::error("If Operation Error: Condition must be Node type 'ref'\n");
+        }
+      } else {
+        Pass::error("If Operation Error: Missing Condition Node\n");
+      }
+    } else {
+      Pass::error("If Operation Error: Not a Valid Node Type\n");
+    }
+  }
+  if (!is_cstmts) {
+    Pass::error("If Operation Error: Missing Condition Statments Node\n");
+  } else if (!is_cond) {
+    Pass::error("If Operation Error: Missing Condition Node\n");
+  } else if (!is_stmts) {
+    Pass::error("If Operation Error: Missing Statements Node\n");
+  }
+}
+
+void Semantic_pass::check_for_op(Lnast* lnast, const Lnast_nid &lnidx_opr) {
+  bool stmts = false;
+  int num_of_ref = 0;
+  for (const auto &lnidx_opr_child : lnast->children(lnidx_opr)) {
+    const auto ntype_child = lnast->get_data(lnidx_opr_child).type;
+
+    if (ntype_child.is_stmts()) {
+      stmts = true;
+      for (const auto &lnidx_opr_child_child : lnast->children(lnidx_opr_child)) {
+        const auto ntype_child_child = lnast->get_data(lnidx_opr_child_child).type;
+        if (is_primitive_op(ntype_child_child)) {
+          check_primitive_ops(lnast, lnidx_opr_child_child, ntype_child_child);
+        } else if (is_tree_structs(ntype_child_child)) {
+          check_if_op(lnast, lnidx_opr_child_child);
+        }
+      }
+    } else if (ntype_child.is_ref()) {
+      num_of_ref += 1;
+    } else {
+      Pass::error("For Operation Error: Not a Valid Node Type\n");
+    }
+  }
+  if (num_of_ref < 2) {
+    Pass::error("For Operation Error: Missing Reference Node(s)\n");
+  } else if(!stmts) {
+    Pass::error("For Operation Error: Missing Statements Node\n");
+  }
+}
+
+void Semantic_pass::check_while_op(Lnast* lnast, const Lnast_nid &lnidx_opr) {
+  bool cond = false;
+  bool stmt = false;
+  for (const auto &lnidx_opr_child : lnast->children(lnidx_opr)) {
+    const auto ntype_child = lnast->get_data(lnidx_opr_child).type;
+
+    if (ntype_child.is_cond()) {
+      cond = true;
+      if (lnast->has_single_child(lnidx_opr_child)) {
+        auto lnidx_opr_child_child = lnast->get_first_child(lnidx_opr_child);
+        auto ntype_child_child = lnast->get_data(lnidx_opr_child_child).type;
+        if (!ntype_child_child.is_ref()) {
+          Pass::error("While Operation Error: Condition must be Node type 'ref'\n");
+        }
+      } else {
+        Pass::error("While Operation Error: Missing Condition Node\n");
+      }
+    } else if (ntype_child.is_stmts()) {
+      stmt = true;
+      for (const auto &lnidx_opr_child_child : lnast->children(lnidx_opr_child)) {
+        const auto ntype_child_child = lnast->get_data(lnidx_opr_child_child).type;
+        if (is_primitive_op(ntype_child_child)) {
+          check_primitive_ops(lnast, lnidx_opr_child_child, ntype_child_child);
+        } else if (is_tree_structs(ntype_child_child)) {
+          check_if_op(lnast, lnidx_opr_child_child);
+        }
+      }
+    } else {
+      Pass::error("While Operation Error: Not a Valid Node Type\n");
+    }
+  }
+  if (!cond) {
+    Pass::error("While Operation Error: Missing Condition Node\n");
+  } else if (!stmt) {
+    Pass::error("While Operation Error: Missing Statement Node\n");
+  }
+}
+
+void Semantic_pass::check_func_def(Lnast* lnast, const Lnast_nid &lnidx_opr) {
+  int num_of_refs = 0;
+  bool cond = false;
+  bool stmts = false;
+  for (const auto &lnidx_opr_child : lnast->children(lnidx_opr)) {
+    const auto ntype_child = lnast->get_data(lnidx_opr_child).type;
+    if (ntype_child.is_cstmts() | ntype_child.is_stmts()) {
+      if (ntype_child.is_stmts()) {
+        stmts = true;
+      }
+      for (const auto &lnidx_opr_child_child : lnast->children(lnidx_opr_child)) {
+        const auto ntype_child_child = lnast->get_data(lnidx_opr_child_child).type;
+        if (is_primitive_op(ntype_child_child)) {
+          check_primitive_ops(lnast, lnidx_opr_child_child, ntype_child_child);
+        } else if (is_tree_structs(ntype_child_child)) {
+          check_if_op(lnast, lnidx_opr_child_child);
+        }
+      }
+    } else if (ntype_child.is_cond()) {
+      if (lnast->has_single_child(lnidx_opr_child)) {
+        cond = true;
+        auto lnidx_opr_child_child = lnast->get_first_child(lnidx_opr_child);
+        auto ntype_child_child = lnast->get_data(lnidx_opr_child_child).type;
+        if (!ntype_child_child.is_const() && !ntype_child_child.is_ref()) {
+          Pass::error("Func Def Operation Error: Condition must be Node type 'ref' or 'const'\n");
+        }
+      } else {
+        Pass::error("Func Def Operation Error: Missing Condition Node\n");
+      }
+    } else if (ntype_child.is_ref()) {
+      num_of_refs += 1;
+    } else {
+      Pass::error("Func Def Operation Error: Not a Valid Node Type\n");
+    }
+  }
+  if (num_of_refs < 1) {
+    Pass::error("Func Def Operation Error: Missing Reference Node\n");
+  } else if (!cond) {
+    Pass::error("Func Def Operation Error: Missing Condition Node\n");
+  } else if (!stmts) {
+    Pass::error("Func Def Operation Error: Missing Statement Node\n");
+  }
+}
+
+void Semantic_pass::check_func_call(Lnast* lnast, const Lnast_nid &lnidx_opr) {
+  int num_of_refs = 0;
+  for (const auto &lnidx_opr_child : lnast->children(lnidx_opr)) {
+    const auto ntype_child = lnast->get_data(lnidx_opr_child).type;
+
+    if (ntype_child.is_ref()) {
+      num_of_refs += 1;
+    } else if (ntype_child.is_ref()) {
+      Pass::error("Func Call Operation Error: Condition must be Node type 'ref'\n");
+    } else {
+      Pass::error("Func Call Operation Error: Not a Valid Node Type\n");
+    }
+  }
+  if (num_of_refs != 3) {
+    Pass::error("Func Call Operation Error: Missing Reference Node(s)\n");
+  }
+}
+
+// NOTE: Test does no consider tuple operations yet
+void Semantic_pass::semantic_check(Lnast* lnast) {
+  // Get Lnast Root
+  const auto top = lnast->get_root();
+  // Get Lnast top statements
+  const auto stmts = lnast->get_first_child(top);
+  // Iterate through Lnast top statements
+  for (const auto &stmt : lnast->children(stmts)) {
+    const auto ntype = lnast->get_data(stmt).type;
+
+    if (is_primitive_op(ntype)) {
+      check_primitive_ops(lnast, stmt, ntype);
+    } else if (ntype.is_if()) {
+      check_if_op(lnast, stmt);
+    } else if (ntype.is_for()) {
+      check_for_op(lnast, stmt);
+    } else if (ntype.is_while()) {
+      check_while_op(lnast, stmt);
+    } else if (ntype.is_func_call()) {
+      check_func_call(lnast, stmt);
+    } else if (ntype.is_func_def()) {
+      check_func_def(lnast, stmt);
+    }
+  }
+}

--- a/pass/semantic/semantic_check.hpp
+++ b/pass/semantic/semantic_check.hpp
@@ -1,0 +1,19 @@
+#pragma once
+
+#include "lnast.hpp"
+
+class Semantic_pass {
+protected:
+  bool is_primitive_op(const Lnast_ntype node_type);
+  bool is_tree_structs(const Lnast_ntype node_type);
+  void check_primitive_ops(Lnast* lnast, const Lnast_nid &lnidx_opr, const Lnast_ntype node_type);
+  void check_if_op(Lnast* lnast, const Lnast_nid &lnidx_opr);
+  void check_for_op(Lnast* lnast, const Lnast_nid &lnidx_opr);
+  void check_while_op(Lnast* lnast, const Lnast_nid &lnidx_opr);
+  void check_func_def(Lnast* lnast, const Lnast_nid &lnidx_opr);
+  void check_func_call(Lnast* lnast, const Lnast_nid &lnidx_opr);
+
+public:
+  // NOTE: Test does no consider tuple operations yet
+  void semantic_check(Lnast* lnast);
+};

--- a/pass/semantic/tests/lnast_semantic_test.cpp
+++ b/pass/semantic/tests/lnast_semantic_test.cpp
@@ -1,0 +1,171 @@
+
+#include "semantic_check.hpp"
+#include "lnast.hpp"
+
+int main(void) {
+
+  int line_num, pos1, pos2 = 0;
+  Lnast* lnast = new Lnast();
+  Semantic_pass s;
+
+  // ======================== Testing Assign Operations ========================
+
+  // auto idx_root    = Lnast_node::create_top    ("top", line_num, pos1, pos2);
+  // auto node_stmts  = Lnast_node::create_stmts  ("stmts", line_num, pos1, pos2);
+  // auto node_assign = Lnast_node::create_assign ("assign", line_num, pos1, pos2);
+  // auto node_target = Lnast_node::create_ref    ("val", line_num, pos1, pos2);
+  // auto node_const  = Lnast_node::create_const  ("0d1023u10", line_num, pos1, pos2);
+
+  // lnast->set_root(idx_root);
+  
+  // auto idx_stmts   = lnast->add_child(lnast->get_root(), node_stmts);
+  // auto idx_assign  = lnast->add_child(idx_stmts,  node_assign);
+  // auto idx_target  = lnast->add_child(idx_assign, node_target);
+  // auto idx_const   = lnast->add_child(idx_assign, node_const);
+
+  // ===========================================================================
+
+  // ==================== Testing N-ary + U-nary Operations ==================== 
+
+  // auto idx_root    = Lnast_node::create_top       ("top",  line_num, pos1, pos2);
+  // auto node_stmts  = Lnast_node::create_stmts     ("stmts",  line_num, pos1, pos2);
+  // auto node_minus  = Lnast_node::create_minus     ("minus",  line_num, pos1, pos2);
+  // auto node_lhs1   = Lnast_node::create_ref       ("___a", line_num, pos1, pos2);
+  // auto node_op1    = Lnast_node::create_ref       ("x",    line_num, pos1, pos2);
+  // auto node_op2    = Lnast_node::create_const     ("0d1",  line_num, pos1, pos2);
+
+  // auto node_plus   = Lnast_node::create_plus      ("plus",  line_num, pos1, pos2);
+  // auto node_lhs2   = Lnast_node::create_ref       ("___b", line_num, pos1, pos2);
+  // auto node_op3    = Lnast_node::create_ref       ("___a", line_num, pos1, pos2);
+  // auto node_op4    = Lnast_node::create_const     ("0d3",  line_num, pos1, pos2);
+  // auto node_op5    = Lnast_node::create_const     ("0d2",  line_num, pos1, pos2);
+
+  // auto node_dpa    = Lnast_node::create_dp_assign ("dp_assign",  line_num, pos1, pos2);
+  // auto node_lhs3   = Lnast_node::create_ref       ("total", line_num, pos1, pos2);
+  // auto node_op6    = Lnast_node::create_ref       ("___b",  line_num, pos1, pos2);
+
+  // lnast->set_root(idx_root);
+
+  // auto idx_stmts   = lnast->add_child(lnast->get_root(), node_stmts);
+  // auto idx_minus   = lnast->add_child(idx_stmts, node_minus);
+  // auto idx_lhs1    = lnast->add_child(idx_minus, node_lhs1);
+  // auto idx_op1     = lnast->add_child(idx_minus, node_op1); 
+  // auto idx_op2     = lnast->add_child(idx_minus, node_op2);
+
+  // auto idx_plus    = lnast->add_child(idx_stmts, node_plus);
+  // auto idx_lhs2    = lnast->add_child(idx_plus,  node_lhs2);
+  // auto idx_op3     = lnast->add_child(idx_plus,  node_op3);
+  // auto idx_op4     = lnast->add_child(idx_plus,  node_op4);
+  // auto idx_op5     = lnast->add_child(idx_plus,  node_op5);
+
+  // auto idx_assign  = lnast->add_child(idx_stmts,  node_dpa);
+  // auto idx_lhs3    = lnast->add_child(idx_assign, node_lhs3);
+  // auto idx_op6     = lnast->add_child(idx_assign, node_op6);
+
+  // ===========================================================================
+
+  // ========================== Testing If Operation ===========================
+  
+  // auto idx_root   = Lnast_node::create_top("top",  line_num, pos1, pos2);
+  // lnast->set_root(idx_root);
+
+  // auto idx_stmts0 = lnast->add_child(lnast->get_root(), Lnast_node::create_stmts ("stmts0",  line_num, pos1, pos2));
+  // auto idx_if     = lnast->add_child(idx_stmts0, Lnast_node::create_if    ("if",  line_num, pos1, pos2));
+
+  // auto idx_cstmts = lnast->add_child(idx_if,     Lnast_node::create_cstmts("cstmts",  line_num, pos1, pos2));
+  // auto idx_gt     = lnast->add_child(idx_cstmts, Lnast_node::create_gt    ("gt",  line_num, pos1, pos2));
+  // auto idx_lhs1   = lnast->add_child(idx_gt,     Lnast_node::create_ref   ("lhs",  line_num, pos1, pos2));
+  // auto idx_op1    = lnast->add_child(idx_gt,     Lnast_node::create_ref   ("op1",  line_num, pos1, pos2));
+  // auto idx_op2    = lnast->add_child(idx_gt,     Lnast_node::create_const ("op2",  line_num, pos1, pos2));
+
+  // auto idx_cond1  = lnast->add_child(idx_if,     Lnast_node::create_cond  ("cond",  line_num, pos1, pos2));
+
+  // auto idx_stmts1 = lnast->add_child(idx_if,     Lnast_node::create_stmts ("stmts1",  line_num, pos1, pos2));
+  // auto idx_plus   = lnast->add_child(idx_stmts1, Lnast_node::create_plus  ("plus",  line_num, pos1, pos2));
+  // auto idx_lhs2   = lnast->add_child(idx_plus,   Lnast_node::create_ref   ("lhs",  line_num, pos1, pos2));
+  // auto idx_op3    = lnast->add_child(idx_plus,   Lnast_node::create_ref   ("op3",  line_num, pos1, pos2));
+  // auto idx_op4    = lnast->add_child(idx_plus,   Lnast_node::create_const ("op4",  line_num, pos1, pos2));
+
+  // auto idx_assign = lnast->add_child(idx_stmts1, Lnast_node::create_assign("assign",  line_num, pos1, pos2));
+  // auto idx_lhs3   = lnast->add_child(idx_assign, Lnast_node::create_ref   ("lhs",  line_num, pos1, pos2));
+  // auto idx_op5    = lnast->add_child(idx_assign, Lnast_node::create_ref   ("op5",  line_num, pos1, pos2));
+  
+  // ============================ For Loop Operation ===========================
+  
+  // auto idx_root      = Lnast_node::create_top("top",  line_num, pos1, pos2);
+  // lnast->set_root(idx_root);
+
+  // auto idx_stmts0    = lnast->add_child(lnast->get_root(), Lnast_node::create_stmts ("stmts0", line_num, pos1, pos2));
+
+  // auto idx_for       = lnast->add_child(idx_stmts0, Lnast_node::create_for    ("for", line_num, pos1, pos2));
+  // auto idx_stmts1    = lnast->add_child(idx_for,    Lnast_node::create_stmts  ("stmts", line_num, pos1, pos2));
+  // auto idx_itr       = lnast->add_child(idx_for,    Lnast_node::create_ref    ("it_name", line_num, pos1, pos2));
+  // auto idx_itr_range = lnast->add_child(idx_for,    Lnast_node::create_ref    ("tup", line_num, pos1, pos2));
+
+  // auto idx_select    = lnast->add_child(idx_stmts1, Lnast_node::create_select ("select", line_num, pos1, pos2)); 
+  // auto idx_lhs       = lnast->add_child(idx_select, Lnast_node::create_ref    ("lhs", line_num, pos1, pos2));
+  // auto idx_op4       = lnast->add_child(idx_select, Lnast_node::create_ref    ("op1", line_num, pos1, pos2));
+  // auto idx_op5       = lnast->add_child(idx_select, Lnast_node::create_ref    ("op2", line_num, pos1, pos2));
+
+  // ===========================================================================
+
+  // =========================== While Loop Operation ==========================
+
+  // auto idx_root    = Lnast_node::create_top("top",  line_num, pos1, pos2);
+  // lnast->set_root(idx_root);
+
+  // auto idx_stmts0  = lnast->add_child(lnast->get_root(), Lnast_node::create_stmts ("stmts0",  line_num, pos1, pos2));
+
+  // auto idx_while   = lnast->add_child(idx_stmts0,  Lnast_node::create_while   ("while",  line_num, pos1, pos2));
+  // auto idx_cond    = lnast->add_child(idx_while,   Lnast_node::create_cond    ("cond",  line_num, pos1, pos2));
+  // auto idx_stmts1  = lnast->add_child(idx_while,   Lnast_node::create_stmts   ("stmts",  line_num, pos1, pos2));
+  // auto idx_ref     = lnast->add_child(idx_cond,    Lnast_node::create_ref     ("condition", line_num, pos1, pos2));
+
+  // ===========================================================================
+
+  // =========================== Func Def Operation ============================
+
+  
+  // auto idx_root    = Lnast_node::create_top("top",  line_num, pos1, pos2);
+  // lnast->set_root(idx_root);
+
+  // auto idx_stmts0  = lnast->add_child(lnast->get_root(), Lnast_node::create_stmts ("stmts0",  line_num, pos1, pos2));
+  // auto idx_func    = lnast->add_child(idx_stmts0, Lnast_node::create_func_def("func_def",  line_num, pos1, pos2));
+
+  // auto idx_fname   = lnast->add_child(idx_func,   Lnast_node::create_ref   ("func_name",  line_num, pos1, pos2));
+  // auto idx_cond    = lnast->add_child(idx_func,   Lnast_node::create_cond  ("condition",  line_num, pos1, pos2));
+  // auto idx_stmts1  = lnast->add_child(idx_func,   Lnast_node::create_stmts ("stmts",  line_num, pos1, pos2));
+  // auto idx_io1     = lnast->add_child(idx_func,   Lnast_node::create_ref   ("in1",  line_num, pos1, pos2));
+  // auto idx_io2     = lnast->add_child(idx_func,   Lnast_node::create_ref   ("in2",  line_num, pos1, pos2));
+  // auto idx_io3     = lnast->add_child(idx_func,   Lnast_node::create_ref   ("out1",  line_num, pos1, pos2));
+
+  // auto idx_ref     = lnast->add_child(idx_cond,    Lnast_node::create_ref  ("true", line_num, pos1, pos2));
+
+  // auto idx_xor     = lnast->add_child(idx_stmts1, Lnast_node::create_xor   ("xor",  line_num, pos1, pos2));
+  // auto idx_lhs_1   = lnast->add_child(idx_xor,    Lnast_node::create_ref   ("lhs",  line_num, pos1, pos2));
+  // auto idx_op1_1   = lnast->add_child(idx_xor,    Lnast_node::create_ref   ("op1",  line_num, pos1, pos2));
+  // auto idx_op2     = lnast->add_child(idx_xor,    Lnast_node::create_ref   ("op2",  line_num, pos1, pos2));
+
+  // auto idx_assign  = lnast->add_child(idx_stmts1, Lnast_node::create_assign("assign",  line_num, pos1, pos2));
+  // auto idx_lhs_2   = lnast->add_child(idx_assign, Lnast_node::create_ref   ("lhs",  line_num, pos1, pos2));
+  // auto idx_op1_2   = lnast->add_child(idx_assign, Lnast_node::create_ref   ("rhs",  line_num, pos1, pos2));
+  
+
+  // ===========================================================================
+
+  // =========================== Func Call Operation ===========================
+
+  // auto idx_root    = Lnast_node::create_top("top",  line_num, pos1, pos2);
+  // lnast->set_root(idx_root);
+
+  // auto idx_stmts0  = lnast->add_child(lnast->get_root(), Lnast_node::create_stmts ("stmts0",  line_num, pos1, pos2));
+  // auto idx_fcall  = lnast->add_child(idx_stmts0, Lnast_node::create_func_call("func_call",  line_num, pos1, pos2));
+  // auto idx_lhs    = lnast->add_child(idx_fcall,  Lnast_node::create_ref      ("lhs",  line_num, pos1, pos2));
+  // auto idx_target = lnast->add_child(idx_fcall,  Lnast_node::create_ref      ("func_name",  line_num, pos1, pos2));
+  // auto idx_arg    = lnast->add_child(idx_fcall,  Lnast_node::create_ref      ("arguments",  line_num, pos1, pos2));
+
+  // ===========================================================================
+
+  s.semantic_check(lnast);
+  return 0;
+}


### PR DESCRIPTION
The semantic check currently checks the top most statement and checks all of the children. Most operations such as unary and n-ary operations, if statements, for statements, while statements, and function call and definition have been implemented with some checks. In each of these operations, the code iterates through operation child nodes and checks for the existence of certain valid nodes. The code does throws errors when certain child nodes do not exist in the operation node (when they are missing) and when incorrect node types are present. I tried to catch as many errors as possible based on the LNAST Documentation provided.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/masc-ucsc/livehd/180)
<!-- Reviewable:end -->
