### PR TITLE
Added support for sourcemaps as a relpacement for Token

### DIFF
--- a/elab/BUILD
+++ b/elab/BUILD
@@ -5,7 +5,8 @@ cc_library(
         ["*.cpp"],
         exclude = ["*test*.cpp"],
         ),
-    hdrs = glob(["*.hpp"]),
+    hdrs = glob(["*.hpp"])
+	 + glob(["*.h"]),
     includes = ["."],
     linkopts = ["-lpthread"],
     visibility = ["//visibility:public"],

--- a/elab/cdecode.c
+++ b/elab/cdecode.c
@@ -1,0 +1,95 @@
+/*
+cdecoder.c - c source to a base64 decoding algorithm implementation
+
+This is part of the libb64 project, and has been placed in the public domain.
+For details, see http://sourceforge.net/projects/libb64
+*/
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <cdecode.h>
+
+int base64_decode_value(char value_in)
+{
+	static const char decoding[] = {62,-1,-1,-1,63,52,53,54,55,56,57,58,59,60,61,-1,-1,-1,-2,-1,-1,-1,0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,-1,-1,-1,-1,-1,-1,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51};
+	static const char decoding_size = sizeof(decoding);
+	value_in -= 43;
+	if (value_in < 0 || value_in >= decoding_size) return -1;
+	return decoding[(int)value_in];
+}
+
+void base64_init_decodestate(base64_decodestate* state_in)
+{
+	state_in->step = step_a;
+	state_in->plainchar = 0;
+}
+
+int base64_decode_block(const char* code_in, const int length_in, char* plaintext_out, base64_decodestate* state_in)
+{
+	const char* codechar = code_in;
+	char* plainchar = plaintext_out;
+	char fragment;
+
+	*plainchar = state_in->plainchar;
+
+	switch (state_in->step)
+	{
+		while (1)
+		{
+	case step_a:
+			do {
+				if (codechar == code_in+length_in)
+				{
+					state_in->step = step_a;
+					state_in->plainchar = *plainchar;
+					return plainchar - plaintext_out;
+				}
+				fragment = (char)base64_decode_value(*codechar++);
+			} while (fragment < 0);
+			*plainchar    = (fragment & 0x03f) << 2;
+	case step_b:
+			do {
+				if (codechar == code_in+length_in)
+				{
+					state_in->step = step_b;
+					state_in->plainchar = *plainchar;
+					return plainchar - plaintext_out;
+				}
+				fragment = (char)base64_decode_value(*codechar++);
+			} while (fragment < 0);
+			*plainchar++ |= (fragment & 0x030) >> 4;
+			*plainchar    = (fragment & 0x00f) << 4;
+	case step_c:
+			do {
+				if (codechar == code_in+length_in)
+				{
+					state_in->step = step_c;
+					state_in->plainchar = *plainchar;
+					return plainchar - plaintext_out;
+				}
+				fragment = (char)base64_decode_value(*codechar++);
+			} while (fragment < 0);
+			*plainchar++ |= (fragment & 0x03c) >> 2;
+			*plainchar    = (fragment & 0x003) << 6;
+	case step_d:
+			do {
+				if (codechar == code_in+length_in)
+				{
+					state_in->step = step_d;
+					state_in->plainchar = *plainchar;
+					return plainchar - plaintext_out;
+				}
+				fragment = (char)base64_decode_value(*codechar++);
+			} while (fragment < 0);
+			*plainchar++   |= (fragment & 0x03f);
+		}
+	}
+	/* control should not reach here */
+	return plainchar - plaintext_out;
+}
+
+#ifdef __cplusplus
+}
+#endif

--- a/elab/cdecode.h
+++ b/elab/cdecode.h
@@ -1,0 +1,108 @@
+/*
+cdecode.h - c header for a base64 decoding algorithm
+
+This is part of the libb64 project, and has been placed in the public domain.
+For details, see http://sourceforge.net/projects/libb64
+*/
+
+#ifndef BASE64_CDECODE_H
+#define BASE64_CDECODE_H
+
+typedef enum
+{
+	step_a, step_b, step_c, step_d
+} base64_decodestep;
+
+typedef struct
+{
+	base64_decodestep step;
+	char plainchar;
+} base64_decodestate;
+
+//void base64_init_decodestate(base64_decodestate* state_in);
+
+//int base64_decode_value(char value_in);
+
+//int base64_decode_block(const char* code_in, const int length_in, char* plaintext_out, base64_decodestate* state_in);
+
+int base64_decode_value(char value_in)
+{
+	static const char decoding[] = {62,-1,-1,-1,63,52,53,54,55,56,57,58,59,60,61,-1,-1,-1,-2,-1,-1,-1,0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,-1,-1,-1,-1,-1,-1,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51};
+	static const char decoding_size = sizeof(decoding);
+	value_in -= 43;
+	if (value_in < 0 || value_in >= decoding_size) return -1;
+	return decoding[(int)value_in];
+}
+
+void base64_init_decodestate(base64_decodestate* state_in)
+{
+	state_in->step = step_a;
+	state_in->plainchar = 0;
+}
+
+int base64_decode_block(const char* code_in, const int length_in, char* plaintext_out, base64_decodestate* state_in)
+{
+	const char* codechar = code_in;
+	char* plainchar = plaintext_out;
+	char fragment;
+
+	*plainchar = state_in->plainchar;
+
+	switch (state_in->step)
+	{
+		while (1)
+		{
+	case step_a:
+			do {
+				if (codechar == code_in+length_in)
+				{
+					state_in->step = step_a;
+					state_in->plainchar = *plainchar;
+					return plainchar - plaintext_out;
+				}
+				fragment = (char)base64_decode_value(*codechar++);
+			} while (fragment < 0);
+			*plainchar    = (fragment & 0x03f) << 2;
+	case step_b:
+			do {
+				if (codechar == code_in+length_in)
+				{
+					state_in->step = step_b;
+					state_in->plainchar = *plainchar;
+					return plainchar - plaintext_out;
+				}
+				fragment = (char)base64_decode_value(*codechar++);
+			} while (fragment < 0);
+			*plainchar++ |= (fragment & 0x030) >> 4;
+			*plainchar    = (fragment & 0x00f) << 4;
+	case step_c:
+			do {
+				if (codechar == code_in+length_in)
+				{
+					state_in->step = step_c;
+					state_in->plainchar = *plainchar;
+					return plainchar - plaintext_out;
+				}
+				fragment = (char)base64_decode_value(*codechar++);
+			} while (fragment < 0);
+			*plainchar++ |= (fragment & 0x03c) >> 2;
+			*plainchar    = (fragment & 0x003) << 6;
+	case step_d:
+			do {
+				if (codechar == code_in+length_in)
+				{
+					state_in->step = step_d;
+					state_in->plainchar = *plainchar;
+					return plainchar - plaintext_out;
+				}
+				fragment = (char)base64_decode_value(*codechar++);
+			} while (fragment < 0);
+			*plainchar++   |= (fragment & 0x03f);
+		}
+	}
+	/* control should not reach here */
+	return plainchar - plaintext_out;
+}
+
+#endif /* BASE64_CDECODE_H */
+

--- a/elab/cencode.c
+++ b/elab/cencode.c
@@ -1,0 +1,116 @@
+/*
+cencoder.c - c source to a base64 encoding algorithm implementation
+
+This is part of the libb64 project, and has been placed in the public domain.
+For details, see http://sourceforge.net/projects/libb64
+*/
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <cencode.h>
+
+const int CHARS_PER_LINE = 72;
+
+void base64_init_encodestate(base64_encodestate* state_in)
+{
+	state_in->step = step_A;
+	state_in->result = 0;
+	state_in->stepcount = 0;
+}
+
+char base64_encode_value(char value_in)
+{
+	static const char* encoding = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+	if (value_in > 63) return '=';
+	return encoding[(int)value_in];
+}
+
+int base64_encode_block(const char* plaintext_in, int length_in, char* code_out, base64_encodestate* state_in)
+{
+	const char* plainchar = plaintext_in;
+	const char* const plaintextend = plaintext_in + length_in;
+	char* codechar = code_out;
+	char result;
+	char fragment;
+
+	result = state_in->result;
+
+	switch (state_in->step)
+	{
+		while (1)
+		{
+	case step_A:
+			if (plainchar == plaintextend)
+			{
+				state_in->result = result;
+				state_in->step = step_A;
+				return codechar - code_out;
+			}
+			fragment = *plainchar++;
+			result = (fragment & 0x0fc) >> 2;
+			*codechar++ = base64_encode_value(result);
+			result = (fragment & 0x003) << 4;
+	case step_B:
+			if (plainchar == plaintextend)
+			{
+				state_in->result = result;
+				state_in->step = step_B;
+				return codechar - code_out;
+			}
+			fragment = *plainchar++;
+			result |= (fragment & 0x0f0) >> 4;
+			*codechar++ = base64_encode_value(result);
+			result = (fragment & 0x00f) << 2;
+	case step_C:
+			if (plainchar == plaintextend)
+			{
+				state_in->result = result;
+				state_in->step = step_C;
+				return codechar - code_out;
+			}
+			fragment = *plainchar++;
+			result |= (fragment & 0x0c0) >> 6;
+			*codechar++ = base64_encode_value(result);
+			result  = (fragment & 0x03f) >> 0;
+			*codechar++ = base64_encode_value(result);
+
+			++(state_in->stepcount);
+			if (state_in->stepcount == CHARS_PER_LINE/4)
+			{
+				*codechar++ = '\n';
+				state_in->stepcount = 0;
+			}
+		}
+	}
+	/* control should not reach here */
+	return codechar - code_out;
+}
+
+int base64_encode_blockend(char* code_out, base64_encodestate* state_in)
+{
+	char* codechar = code_out;
+
+	switch (state_in->step)
+	{
+	case step_B:
+		*codechar++ = base64_encode_value(state_in->result);
+		*codechar++ = '=';
+		*codechar++ = '=';
+		break;
+	case step_C:
+		*codechar++ = base64_encode_value(state_in->result);
+		*codechar++ = '=';
+		break;
+	case step_A:
+		break;
+	}
+	*codechar++ = '\n';
+
+	return codechar - code_out;
+}
+
+#ifdef __cplusplus
+}
+#endif

--- a/elab/cencode.h
+++ b/elab/cencode.h
@@ -1,0 +1,133 @@
+/*
+cencode.h - c header for a base64 encoding algorithm
+
+This is part of the libb64 project, and has been placed in the public domain.
+For details, see http://sourceforge.net/projects/libb64
+*/
+
+#ifndef BASE64_CENCODE_H
+#define BASE64_CENCODE_H
+
+typedef enum
+{
+	step_A, step_B, step_C
+} base64_encodestep;
+
+typedef struct
+{
+	base64_encodestep step;
+	char result;
+	int stepcount;
+} base64_encodestate;
+
+//void base64_init_encodestate(base64_encodestate* state_in);
+
+//char base64_encode_value(char value_in);
+
+//int base64_encode_block(const char* plaintext_in, int length_in, char* code_out, base64_encodestate* state_in);
+
+//int base64_encode_blockend(char* code_out, base64_encodestate* state_in);
+
+const int CHARS_PER_LINE = 72;
+
+void base64_init_encodestate(base64_encodestate* state_in)
+{
+	state_in->step = step_A;
+	state_in->result = 0;
+	state_in->stepcount = 0;
+}
+
+char base64_encode_value(char value_in)
+{
+	static const char* encoding = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+	if (value_in > 63) return '=';
+	return encoding[(int)value_in];
+}
+
+int base64_encode_block(const char* plaintext_in, int length_in, char* code_out, base64_encodestate* state_in)
+{
+	const char* plainchar = plaintext_in;
+	const char* const plaintextend = plaintext_in + length_in;
+	char* codechar = code_out;
+	char result;
+	char fragment;
+
+	result = state_in->result;
+
+	switch (state_in->step)
+	{
+		while (1)
+		{
+	case step_A:
+			if (plainchar == plaintextend)
+			{
+				state_in->result = result;
+				state_in->step = step_A;
+				return codechar - code_out;
+			}
+			fragment = *plainchar++;
+			result = (fragment & 0x0fc) >> 2;
+			*codechar++ = base64_encode_value(result);
+			result = (fragment & 0x003) << 4;
+	case step_B:
+			if (plainchar == plaintextend)
+			{
+				state_in->result = result;
+				state_in->step = step_B;
+				return codechar - code_out;
+			}
+			fragment = *plainchar++;
+			result |= (fragment & 0x0f0) >> 4;
+			*codechar++ = base64_encode_value(result);
+			result = (fragment & 0x00f) << 2;
+	case step_C:
+			if (plainchar == plaintextend)
+			{
+				state_in->result = result;
+				state_in->step = step_C;
+				return codechar - code_out;
+			}
+			fragment = *plainchar++;
+			result |= (fragment & 0x0c0) >> 6;
+			*codechar++ = base64_encode_value(result);
+			result  = (fragment & 0x03f) >> 0;
+			*codechar++ = base64_encode_value(result);
+
+			++(state_in->stepcount);
+			if (state_in->stepcount == CHARS_PER_LINE/4)
+			{
+				*codechar++ = '\n';
+				state_in->stepcount = 0;
+			}
+		}
+	}
+	/* control should not reach here */
+	return codechar - code_out;
+}
+
+int base64_encode_blockend(char* code_out, base64_encodestate* state_in)
+{
+	char* codechar = code_out;
+
+	switch (state_in->step)
+	{
+	case step_B:
+		*codechar++ = base64_encode_value(state_in->result);
+		*codechar++ = '=';
+		*codechar++ = '=';
+		break;
+	case step_C:
+		*codechar++ = base64_encode_value(state_in->result);
+		*codechar++ = '=';
+		break;
+	case step_A:
+		break;
+	}
+	*codechar++ = '\n';
+
+	return codechar - code_out;
+}
+
+
+#endif /* BASE64_CENCODE_H */
+

--- a/elab/decode.h
+++ b/elab/decode.h
@@ -1,0 +1,70 @@
+// :mode=c++:
+/*
+decode.h - c++ wrapper for a base64 decoding algorithm
+
+This is part of the libb64 project, and has been placed in the public domain.
+For details, see http://sourceforge.net/projects/libb64
+*/
+#ifndef BASE64_DECODE_H
+#define BASE64_DECODE_H
+
+#include <iostream>
+
+namespace base64
+{
+	extern "C"
+	{
+		#include "cdecode.h"
+	}
+
+	struct decoder
+	{
+		base64_decodestate _state;
+		int _buffersize;
+
+		decoder(int buffersize_in = BUFFERSIZE)
+		: _buffersize(buffersize_in)
+		{}
+
+		int decode(char value_in)
+		{
+			return base64_decode_value(value_in);
+		}
+
+		int decode(const char* code_in, const int length_in, char* plaintext_out)
+		{
+			return base64_decode_block(code_in, length_in, plaintext_out, &_state);
+		}
+
+		void decode(std::istream& istream_in, std::ostream& ostream_in)
+		{
+			base64_init_decodestate(&_state);
+			//
+			const int N = _buffersize;
+			char* code = new char[N];
+			char* plaintext = new char[N];
+			int codelength;
+			int plainlength;
+
+			do
+			{
+				istream_in.read((char*)code, N);
+				codelength = istream_in.gcount();
+				plainlength = decode(code, codelength, plaintext);
+				ostream_in.write((const char*)plaintext, plainlength);
+			}
+			while (istream_in.good() && codelength > 0);
+			//
+			base64_init_decodestate(&_state);
+
+			delete [] code;
+			delete [] plaintext;
+		}
+	};
+
+} // namespace base64
+
+
+
+#endif // BASE64_DECODE_H
+

--- a/elab/document.cpp
+++ b/elab/document.cpp
@@ -1,0 +1,688 @@
+// include library
+#include <omp.h>
+#include <string>
+#include <istream>
+#include <ostream>
+#include <iostream>
+#include <fstream>
+#include <sstream>
+#include <stdexcept>
+#include <algorithm>
+
+#ifndef BUFFERSIZE
+#define BUFFERSIZE 1024
+#endif
+
+// our own header
+#include "sourcemap.hpp"
+#include "document.hpp"
+#include "decode.h"
+
+JsonNode* json_import(const char* str) {
+	if (std::string(str) == "null") { return json_mknull(); }
+	else if (std::string(str) == "true") { return json_mkbool(true); }
+	else if (std::string(str) == "false") { return json_mkbool(false); }
+	else { return json_mkstring(str); }
+}
+
+#define json_double(json_node)           \
+  (!json_node ? -1 :                     \
+      json_node->tag == JSON_NUMBER ?    \
+        json_node->number_ :             \
+      json_node->tag == JSON_STRING ?    \
+        atof(json_node->string_) :       \
+          -1                             \
+  )
+
+#define json_export(json_node)           \
+  (!json_node ? "null" : string(         \
+      json_node->tag == JSON_STRING ?    \
+        json_node->string_ :             \
+          json_stringify(json_node, "")  \
+  ))
+
+// add namespace for c++
+namespace SourceMap
+{
+
+  std::istream& getline(std::istream& is, std::string& t)
+  {
+      t.clear();
+
+      // The characters in the stream are read one-by-one using a std::streambuf.
+      // That is faster than reading them one-by-one using the std::istream.
+      // Code that uses streambuf this way must be guarded by a sentry object.
+      // The sentry object performs various tasks,
+      // such as thread synchronization and updating the stream state.
+
+      std::istream::sentry se(is, true);
+      std::streambuf* sb = is.rdbuf();
+
+      for(;;) {
+          int c = sb->sbumpc();
+          switch (c) {
+          case '\n':
+              return is;
+          case '\r':
+              if(sb->sgetc() == '\n')
+                  sb->sbumpc();
+              return is;
+          case EOF:
+              // Also handle the case when the last line has no line ending
+              if(t.empty())
+                  is.setstate(std::ios::eofbit);
+              return is;
+          default:
+              t += (char)c;
+          }
+      }
+  }
+
+	SrcMapDoc::SrcMapDoc ()
+	{
+		this->map = make_shared<Mappings>();
+	}
+
+	SrcMapDoc::~SrcMapDoc ()
+	{ }
+
+	SrcMapDoc::SrcMapDoc (const JsonNode& json_node)
+	{
+		this->init(json_node);
+	}
+
+	bool match(const string& haystack, const string& needle, size_t& i)
+	{
+		size_t l = needle.length();
+		while (isspace(haystack[i])) ++i;
+		if (haystack.substr(i, l) == needle) {
+			i += l; return true;
+		}
+		return false;
+	}
+
+	SrcMapDoc::SrcMapDoc(const string& str)
+	{
+		// decode the json string first into a json_node
+		std::string line;
+		std::istringstream s(str);
+		while(std::getline(s, line))
+		{
+
+			size_t i = 0;
+			if (!match(line, "/*#", i)) continue;
+			if (!match(line, "sourceMappingURL", i)) continue;
+			if (!match(line, "=", i)) continue;
+			if (!match(line, "data", i)) continue;
+			if (!match(line, ":", i)) continue;
+			if (!match(line, "application/json", i)) continue;
+			if (!match(line, ";", i)) continue;
+			if (!match(line, "base64", i)) continue;
+			if (!match(line, ",", i)) continue;
+			while (isspace(line[i])) ++i;
+			size_t start = i;
+			while (line[i]) {
+				const char c = line[i];
+				if (c >= 'A' && c <= 'Z') { ++i; continue; }
+				if (c >= 'a' && c <= 'z') { ++i; continue; }
+				if (c >= '0' && c <= '9') { ++i; continue; }
+				if (c == '+' || c == '/') { ++i; continue; }
+				if (c == '=' || c == '=') { ++i; continue; }
+				break;
+			}
+			size_t stop = i;
+
+			string istr(line.substr(start, stop - start));
+			base64::decoder E;
+			istringstream istrm(istr);
+			stringstream ostrm;
+			E.decode(istrm, ostrm);
+			string ostr(ostrm.str());
+
+			JsonNode* json_node = json_decode(ostr.c_str());
+			if (!json_node) throw(runtime_error("invalid json_node"));
+			this->init(*json_node);
+			return;
+
+		}
+
+		JsonNode* json_node = json_decode(str.c_str());
+		if (!json_node) throw(runtime_error("invalid json_node"));
+
+		this->init(*json_node);
+	}
+
+	const ColMapSP SrcMapDoc::getColMap(size_t row, size_t idx) const
+	{
+		return map->getLineMap(row)->getColMap(idx);
+	}
+	const ColMapSP SrcMapDoc::getColMap(const SrcMapIdx& idx) const
+	{
+		return map->getLineMap(idx.row)->getColMap(idx.idx);
+	}
+	const vector<ColMapSP> SrcMapDoc::at(size_t row, size_t col) const
+	{
+		return map->getLineMap(row)->at(col);
+	}
+	const vector<ColMapSP> SrcMapDoc::at(const SrcMapPos& pos) const
+	{
+		return map->getLineMap(pos.row)->at(pos.col);
+	}
+
+	const string SrcMapDoc::getFile() const { return file; }
+	const string SrcMapDoc::getRoot() const { return root; }
+	const MappingsSP SrcMapDoc::getMap() const { return map; }
+
+	const string SrcMapDoc::getToken(size_t idx) const
+	{
+		if (idx < 0 || idx >= tokens.size())
+		{ throw(runtime_error("token access out of bound")); }
+		return tokens[idx];
+	}
+
+	const string SrcMapDoc::getSource(size_t idx) const
+	{
+		if (idx < 0 || idx >= sources.size())
+		{ throw(runtime_error("source access out of bound")); }
+		return sources[idx];
+	}
+
+	const string SrcMapDoc::getContent(size_t idx) const
+	{
+		if (idx < 0 || idx >= contents.size())
+		{ throw(runtime_error("content access out of bound")); }
+		return contents[idx];
+	}
+
+	ostream& operator<<(ostream& os, const ColMap& entry)
+	{
+		if (entry.getType() == 1) {
+			return os << "[" << entry.col << "]";
+		} else if (entry.getType() == 4) {
+			return os << "[" << entry.col << "," << entry.src_idx <<
+			       "," << entry.src_line << "," << entry.src_col << "]";
+		} else if (entry.getType() == 5) {
+			return os << "[" << entry.col << "," << entry.src_idx <<
+			       "," << entry.src_line << "," << entry.src_col <<
+			       "," << entry.tkn_idx << "]";
+		} else {
+			return os;
+		}
+	}
+
+	ostream& operator<<(ostream& os, const Mappings& map)
+	{
+		size_t count = 0; // count total number of entries
+		const_foreach(LineMapSP, row, map.rows) count += (*row)->getLength();
+		return os << "{" << map.rows.size() << ":" << count << "}";
+	}
+
+	ostream& operator<<(ostream& os, const SrcMapPos& pos)
+	{
+		return os << "[" << pos.row << "|" << pos.col << "]";
+	}
+
+
+	void SrcMapDoc::init (const JsonNode& json_cnode)
+	{
+
+
+		// remove constness ???!!
+		JsonNode json_node = json_cnode;
+
+		if (json_node.tag == JSON_OBJECT) {
+
+			JsonNode* json_file = json_find_member(&json_node, "file"); // string
+			JsonNode* json_root = json_find_member(&json_node, "sourceRoot"); // string
+			JsonNode* json_version = json_find_member(&json_node, "version"); // string
+			JsonNode* json_mappings = json_find_member(&json_node, "mappings"); // string
+			JsonNode* json_tokens = json_find_member(&json_node, "names"); // array
+			JsonNode* json_sources = json_find_member(&json_node, "sources"); // array
+			JsonNode* json_contents = json_find_member(&json_node, "sourcesContent"); // array
+			JsonNode* json_lastLineLength = json_find_member(&json_node, "x_lastLineSize"); // string
+
+			file = json_export(json_file);
+			root = json_export(json_root);
+			version = json_export(json_version);
+
+			// assetion for version (must be defined first in source map!)
+			if (json_export(json_version) != "3") {
+				// must be defined first in source map actually
+				throw(runtime_error("only source map version 3 is supported"));
+			}
+
+			if (json_tokens && (
+					json_tokens->tag == JSON_ARRAY ||
+					json_tokens->tag == JSON_OBJECT
+			)) {
+				JsonNode* json_token(0);
+				json_foreach(json_token, json_tokens) {
+					tokens.push_back(json_export(json_token));
+				}
+			}
+
+			if (json_sources && (
+					json_sources->tag == JSON_ARRAY ||
+					json_sources->tag == JSON_OBJECT
+			)) {
+				JsonNode* json_source(0);
+				json_foreach(json_source, json_sources) {
+					sources.push_back(json_export(json_source));
+				}
+			}
+
+			if (json_contents && (
+					json_contents->tag == JSON_ARRAY ||
+					json_contents->tag == JSON_OBJECT
+			)) {
+				JsonNode* json_content(0);
+				json_foreach(json_content, json_contents) {
+					contents.push_back(json_export(json_content));
+				}
+			}
+
+			map = SourceMap::make_shared<Mappings>(json_export(json_mappings));
+
+			map->last_ln_col = (int) json_double(json_lastLineLength);
+
+		}
+
+	}
+
+	char* SrcMapDoc::serialize(bool enc) const
+	{
+
+		JsonNode* json_node = json_mkobject();
+
+		// version must be the first thing (by specification)
+		json_append_member(json_node, "version", json_mknumber(3));
+
+		JsonNode* json_file = json_import(file.c_str());
+		json_append_member(json_node, "file", json_file);
+
+		size_t sources_size = sources.size();
+		JsonNode* json_sources = json_mkarray();
+		for (size_t i = 0; i < sources_size; ++i) {
+			const char* include = sources[i].c_str();
+			JsonNode* json_source = json_import(include);
+			json_append_element(json_sources, json_source);
+		}
+		json_append_member(json_node, "sources", json_sources);
+
+		size_t contents_size = contents.size();
+		JsonNode* json_contents = json_mkarray();
+		for (size_t i = 0; i < contents_size; ++i) {
+			const char* content = contents[i].c_str();
+			JsonNode* json_content = json_import(content);
+			json_append_element(json_contents, json_content);
+		}
+		json_append_member(json_node, "sourcesContent", json_contents);
+
+		string mappings = map->serialize();
+		JsonNode* json_mappings = json_import(mappings.c_str());
+		json_append_member(json_node, "mappings", json_mappings);
+
+		size_t tokens_size = tokens.size();
+		JsonNode* json_tokens = json_mkarray();
+		for (size_t i = 0; i < tokens_size; ++i) {
+			const char* token = tokens[i].c_str();
+			JsonNode* json_token = json_import(token);
+			json_append_element(json_tokens, json_token);
+		}
+		json_append_member(json_node, "names", json_tokens);
+
+		// insert optional and custom attribute to store the last line length
+		// this information would otherwise be lost and is needed for appends etc.
+		json_append_member(json_node, "x_lastLineSize", json_mknumber(map->last_ln_col));
+
+		// get string from json encode
+		// caller must free it himself
+		char* str = json_encode(json_node);
+		json_delete(json_node);
+		return str;
+
+	}
+
+
+
+
+
+
+
+
+	// add sources from srcmap to our own
+	// update mappings from srcmap to new index
+	void SrcMapDoc::mergePrepare(SrcMapDoc srcmap)
+	{
+
+		foreach(string, source, srcmap.sources) {
+			sources.push_back(*source);
+		}
+
+		size_t offset = sources.size();
+
+		if (true) {
+			const_foreach(LineMapSP, row, srcmap.map->rows) {
+				cerr << (*row)->entries.size() << endl;
+			}
+		}
+
+		foreach(LineMapSP, row, srcmap.map->rows) {
+			foreach(ColMapSP, entry, (*row)->entries) {
+				if ((*entry)->getType() > 0)
+					(*entry)->src_idx += offset;
+			}
+		}
+
+	}
+
+	void SrcMapDoc::append(LineMap row)
+	{
+	}
+	void SrcMapDoc::prepend(LineMap row)
+	{
+	}
+
+	void SrcMapDoc::remap(SrcMapDoc srcmap)
+	{
+
+		size_t i = 0;
+
+		//double start = omp_get_wtime();
+		//double end = omp_get_wtime();
+
+		size_t offset = sources.size();
+
+		foreach(string, source, srcmap.sources) {
+			sources.push_back(*source);
+		}
+
+		foreach(LineMapSP, row, map->rows) {
+			foreach_ptr(ColMap, entry, (*row)->entries) {
+
+				if (entry->src_idx != 0) continue;
+
+				// our own source map can only be of one file
+				vector<ColMapSP> originals = srcmap.map->rows[i]->at(entry->getCol());
+
+				if (originals.size() >= 1) {
+					const_foreach_ptr(ColMap, original, originals) {
+						if (entry->getType() > 0) {
+							entry->col = original->col;
+						}
+						if (entry->getType() > 3) {
+							entry->src_idx = original->src_idx + offset;
+							entry->src_line = original->src_line;
+							entry->src_col = original->src_col;
+						}
+						if (entry->getType() > 4) {
+							entry->tkn_idx = original->tkn_idx;
+						}
+					}
+				}
+			}
+			++i;
+		}
+		//end = omp_get_wtime();
+
+		//cerr << "Benchmark: " << (end - start) << endl;
+		cerr << "Benchmark: (missing, disabled omp_get_wtime)" << endl;
+
+	}
+
+	// STL helper
+	struct adjust_col
+	{
+		public:
+			adjust_col(int off) : offset(off) {}
+			void operator()(ColMapSP entry)
+			{
+				entry->setCol(entry->getCol() + offset);
+			}
+		private:
+			int offset;
+	};
+
+	void SrcMapDoc::insert(SrcMapPos pos, const SrcMapDoc& srcmap)
+	{
+		// ToDo: adapt srcmap for insert
+		insert(pos, *srcmap.map);
+	}
+
+	// bread and butter function that implements all operations
+	void SrcMapDoc::splice(SrcMapPos pos, SrcMapPos del, const SrcMapDoc& srcmap)
+	{
+		// ToDo: adapt splice for insert
+		splice(pos, del, *srcmap.map);
+	}
+
+
+
+
+
+	void SrcMapDoc::remove(SrcMapPos pos, SrcMapPos del)
+	{
+
+		// some basic assertions to avoid strange bugs
+		if (pos.col == string::npos) throw(invalid_argument("remove pos.col is invalid"));
+		if (pos.row == string::npos) throw(invalid_argument("remove pos.row is invalid"));
+		if (del.col == string::npos) throw(invalid_argument("remove del.col is invalid"));
+		if (del.row == string::npos) throw(invalid_argument("remove del.row is invalid"));
+		if (map->getLastRowSize() == string::npos) throw(invalid_argument("remove size.col is invalid"));
+		if (map->getRowCount() == string::npos) throw(invalid_argument("remove size.row is invalid"));
+		// check for access violations
+		if (map->rows.size() == 0) throw(runtime_error("empty srcmap"));
+		if (map->rows.size() <= pos.row) throw(out_of_range("access out of bound"));
+		if (map->rows.size() <= pos.row + del.row) throw(out_of_range("delete out of bound"));
+
+		// find the position where the remove should be placed
+		vector<ColMapSP> &first_row = map->rows[pos.row]->entries;
+		vector<ColMapSP>::iterator pos_it = first_row.begin();
+		vector<ColMapSP>::iterator first_row_end = first_row.end();
+		// loop until we reach the remove position
+		for(; pos_it != first_row_end; ++pos_it)
+		{ if ((*pos_it)->col >= pos.col) break; }
+		// also get a numeric offset, since any
+		// insertion will invalidate all iterators
+		// size_t pos_idx = pos_it - first_row.begin();
+
+		if (del.row > 0) {
+
+			// erase everything after the pos.col
+			first_row.erase(pos_it, first_row_end);
+
+			vector<ColMapSP> &last_row = map->rows[pos.row + del.row]->entries;
+			vector<ColMapSP>::iterator last_row_it = last_row.begin();
+			vector<ColMapSP>::iterator last_row_end = last_row.end();
+			// loop until we reach the remove position
+			for(; last_row_it != last_row_end; ++last_row_it)
+			{ if ((*last_row_it)->col >= del.col) break; }
+
+			// adjust the remaining entries for the removed range
+			for_each(last_row_it, last_row.end(), adjust_col(- del.col));
+
+			first_row.insert(
+				first_row.end(),
+				last_row_it,
+				last_row.end()
+			);
+
+			// remove entries from the last line to remove
+			// last_row.erase(last_row.begin(), last_row_it);
+
+			// remove full lines
+			// excluding the last
+			map->rows.erase(
+				map->rows.begin() + pos.row + 1,
+				map->rows.begin() + pos.row + 1 + del.row
+			);
+
+		} else {
+
+			vector<ColMapSP>::iterator remove_it = pos_it;
+			// loop until we reach the remove position
+			for(; remove_it != first_row_end; ++remove_it)
+			{ if ((*remove_it)->col >= pos.col + del.col) break; }
+			// adjust the remaining entries for the removed range
+			for_each(remove_it, first_row.end(), adjust_col(- del.col));
+			// remove the range we have found
+			first_row.erase(pos_it, remove_it);
+
+		}
+
+		// sync the row size stat variable
+		// ToDo: use other way, too error prone
+		// map->size.row = map->rows.size();
+
+	}
+	// EO remove
+
+	void SrcMapDoc::insert(SrcMapPos pos, const Mappings& insert)
+	{
+
+		// some basic assertions to avoid strange bugs
+		if (pos.col == string::npos) throw(invalid_argument("insert pos.col is invalid"));
+		if (pos.row == string::npos) throw(invalid_argument("insert pos.row is invalid"));
+		if (map->getLastRowSize() == string::npos) throw(invalid_argument("remove size.col is invalid"));
+		if (map->getRowCount() == string::npos) throw(invalid_argument("remove size.row is invalid"));
+		if (insert.getLastRowSize() == string::npos) throw(invalid_argument("insert insert.col is invalid"));
+		if (insert.getRowCount() == string::npos) throw(invalid_argument("insert insert.row is invalid"));
+		// check for access violations
+		if (map->rows.size() == 0) throw(runtime_error("empty srcmap"));
+		if (map->rows.size() <= pos.row) throw(out_of_range("access out of bound"));
+
+		// find the position where the insert should be placed
+		vector<ColMapSP> &first_row = map->rows[pos.row]->entries;
+		vector<ColMapSP>::iterator insert_it = first_row.begin();
+		vector<ColMapSP>::iterator first_row_end = first_row.end();
+		// loop until we reach the insert position
+		for(; insert_it != first_row_end; ++insert_it)
+		{ if ((*insert_it)->col >= pos.col) break; }
+		// also get a numeric offset, since any
+		// insertion will invalidate all iterators
+		size_t ins_idx = insert_it - first_row.begin();
+
+		// splitting up a row
+		if (insert.rows.size() > 1) {
+
+			// adjust trailing entries to account for new offset
+			for_each(insert_it, first_row_end, adjust_col(insert.getLastRowSize() - pos.col));
+
+			// insert all full lines
+			// excluding the first line
+			map->rows.insert(
+				map->rows.begin() + pos.row + 1,
+				insert.rows.begin() + 1, insert.rows.end()
+			);
+
+			size_t ins_row = insert.getRowCount() - 1;
+			// move trailing entries from the first line of insert
+			// to the last line that has been inserted previously
+			map->rows[pos.row + ins_row]->entries.insert(
+				map->rows[pos.row + ins_row]->entries.end(),
+				map->rows[pos.row]->entries.begin() + ins_idx,
+				map->rows[pos.row]->entries.end()
+			);
+
+			// get position to up we will remove the items later
+			// we do not remove them right away, as we possibly have
+			// the same vector in map and insert. Therefore we first
+			// want to make the copy before removing the entries!
+			size_t del_stop_idx = map->rows[pos.row]->entries.size();
+
+			// copy entries of first line to be inserted
+			// they go the the end of the first insert line
+			map->rows[pos.row]->entries.insert(
+				map->rows[pos.row]->entries.end(),
+				insert.rows[0]->entries.begin(),
+				insert.rows[0]->entries.end()
+			);
+
+			// remove entries that have been moved
+			map->rows[pos.row]->entries.erase(
+				map->rows[pos.row]->entries.begin() + ins_idx,
+				map->rows[pos.row]->entries.begin() + del_stop_idx
+			);
+
+		// operate on existing row
+		} else if (insert.rows.size() == 1) {
+
+			// operation is only done on one single line
+			vector<ColMapSP> insert_row = insert.rows[0]->entries;
+			// adjust the offset to account for inserted data
+			for_each(insert_it, first_row_end, adjust_col(insert.getLastRowSize()));
+			// then copy the complete first line to be inserted
+			first_row.insert(insert_it, insert_row.begin(), insert_row.end());
+			// restore the iterator after insertion
+			insert_it = first_row.begin() + ins_idx;
+			// adjust the offset for the inserts by insert position
+			for_each(insert_it, insert_it + insert_row.size(), adjust_col(pos.col));
+
+		} else {
+
+			invalid_argument("insert.size.row is invalid");
+
+		}
+
+		// sync the row size stat variable
+		// ToDo: use other way, too error prone
+		// map->size.row = map->rows.size();
+
+	}
+	// EO insert
+
+	// bread and butter function that implements all operations
+	void SrcMapDoc::splice(SrcMapPos pos, SrcMapPos del, const Mappings& map)
+	{
+
+		remove(pos, del);
+		insert(pos, map);
+
+	}
+
+	void SrcMapDoc::addSource(string file)
+	{
+		sources.push_back(file);
+	}
+	void SrcMapDoc::addToken(string token)
+	{
+		tokens.push_back(token);
+	}
+
+	// insert an entry at the given position
+	void SrcMapDoc::insert(size_t row, ColMapSP entry, bool after)
+	{
+		// make sure we have enough room (needed for lookup)
+		while (map->rows.size() <= row) { map->addNewLine(); }
+		// create position object to pass as argument
+		SrcMapPos pos = SrcMapPos(row, entry->getCol() + after);
+		// get entries object from row to work on
+		vector<ColMapSP> &entries = map->rows[pos.row]->entries;
+		// find the position where the insert should be placed
+		vector<ColMapSP>::iterator entry_it = entries.begin();
+		vector<ColMapSP>::iterator entry_end = entries.end();
+		// loop until we have found the position
+		for(; entry_it != entry_end; ++entry_it)
+		{ if ((*entry_it)->col >= pos.col) break; }
+		// insert at end if no position found
+		entries.insert(entry_it, entry);
+	}
+
+
+
+
+
+	void SrcMapDoc::setLastLineLength(size_t col)
+	{
+		map->last_ln_col = col;
+	}
+
+
+}
+// EO namespace
+
+// implement for c
+extern "C"
+{
+
+}

--- a/elab/document.hpp
+++ b/elab/document.hpp
@@ -1,0 +1,150 @@
+#ifndef SOURCEMAP_SRCMAP
+#define SOURCEMAP_SRCMAP
+
+#ifdef __cplusplus
+
+#include <vector>
+#include <string>
+#include <cstring>
+#include <iostream>
+#include <fstream>
+
+#include "json.hpp"
+#include "sourcemap.hpp"
+
+#include "map_line.hpp"
+#include "map_col.hpp"
+#include "mappings.hpp"
+
+#ifndef VERSION
+#define VERSION "[NA]"
+#endif
+
+// add namespace for c++
+namespace SourceMap
+{
+
+	// define version from arguments
+	// compile with g++ -DVERSION="\"vX.X.X\""
+	const string SOURCEMAP_VERSION = VERSION;
+
+	/****************************************************************************/
+	/****************************************************************************/
+
+
+	/****************************************************************************/
+	/****************************************************************************/
+
+
+	/****************************************************************************/
+	/****************************************************************************/
+
+
+	class SrcMapDoc PANDA_INHERIT
+	{
+		friend class ColMap;
+		friend class LineMap;
+		friend class Mappings;
+
+		public: // ctor
+			SrcMapDoc();
+			SrcMapDoc(const string& json_str);
+			SrcMapDoc(const JsonNode& json_node);
+			virtual ~SrcMapDoc();
+
+		public: // setters
+			// append to the vectors
+			void addToken(string token);
+			void addSource(string file);
+			// get index or add to vector
+			size_t pushToken(string token);
+			size_t pushSource(string file);
+
+		public: // getters
+			const string getFile() const;
+			const string getRoot() const;
+			const MappingsSP getMap() const;
+			// access the vectors
+			const string getToken(size_t idx) const;
+			const string getSource(size_t idx) const;
+			const string getContent(size_t idx) const;
+			// get size of the vectors
+			size_t getRowSize() const { return map->rows.size(); };
+			size_t getTokenSize() const { return tokens.size(); };
+			size_t getSourceSize() const { return sources.size(); };
+			// use enc to disable map encoding
+			char* serialize(bool enc = true) const;
+
+		public: // methods
+			// truncate or increase size
+			// call before adding entries
+			void truncate(SrcMapPos size);
+
+			// insert the map at the given position
+			// ToDo: means size needs to go on to map
+			// sourcemaps first needs to adapt mappings
+			void insert(SrcMapPos pos, const Mappings& map);
+			void insert(SrcMapPos pos, const SrcMapDoc& srcmap);
+
+			// delete the given size from position
+			// will truncate the size accordingly
+			// only possible because we now the number
+			// of columns to be be removed from caller
+			void remove(SrcMapPos pos, SrcMapPos del);
+
+			// main manipulation method (delete/insert)
+			// ToDo: means size needs to go on to map
+			// sourcemaps first needs to adapt mappings
+			void splice(SrcMapPos pos, SrcMapPos del, const Mappings& map);
+			void splice(SrcMapPos pos, SrcMapPos del, const SrcMapDoc& srcmap);
+
+			// remap is a specific operation to remap/merge an
+			// intermediate source-map to its original content
+			void remap(SrcMapDoc srcmap);
+
+
+			// main manipulation method (delete/insert)
+
+
+			void append(LineMap row);
+			void prepend(LineMap row);
+
+			void insert(size_t row, ColMapSP entry, bool after = false);
+
+			void mergePrepare(SrcMapDoc srcmap);
+			void setLastLineLength(size_t col);
+
+		public: // route to other functions
+			const ColMapSP getColMap(size_t row, size_t idx) const;
+			const ColMapSP getColMap(const SrcMapIdx& idx) const;
+			const ColMapArr at(size_t row, size_t col) const;
+			const ColMapArr at(const SrcMapPos& pos) const;
+
+		public: // variables
+			string file;
+			string root;
+			MappingsSP map;
+			string version;
+			vector<string> tokens;
+			vector<string> sources;
+			vector<string> contents;
+			void init(const JsonNode& json_node);
+	};
+
+	// typedef weak_ptr<SrcMapDoc> SrcMapWP;
+	typedef shared_ptr<SrcMapDoc> SrcMapDocSP;
+
+}
+// EO namespace
+
+// declare for c
+extern "C" {
+#endif
+
+// void foobar();
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/elab/elab_scanner.cpp
+++ b/elab/elab_scanner.cpp
@@ -61,7 +61,80 @@ void Elab_scanner::setup_translate() {
   translate['\\'] = Token_id_backslash;
 }
 
+
+void Elab_scanner::patch_pass(const absl::flat_hash_map<std::string, Token_id> &keywords) {
+  if (use_Token)
+    Token_patch_pass(keywords);
+  else
+    SrcMap_patch_pass(keywords);
+}
+
+void Elab_scanner::parse_step() {
+  if (use_Token)
+    Token_parse_step();
+  else
+    SrcMap_parse_step();
+}
+
+void Elab_scanner::parse_setup(std::string_view filename) {
+  if (use_Token)
+    Token_parse_setup(filename);
+  else
+    SrcMap_parse_setup(filename);
+}
+
+void Elab_scanner::parse_setup() {
+  if (use_Token)
+    Token_parse_setup();
+  else
+    SrcMap_parse_setup();
+}
+
+bool Elab_scanner::scan_next() {
+  if (use_Token)
+    return Token_scan_next();
+  else
+    return SrcMap_scan_next();
+}
+
+void Elab_scanner::scan_format_append(std::string &text) const {
+  if (use_Token)
+    Token_scan_format_append(text);
+  else
+    SrcMap_scan_format_append(text);
+}
+
+void Elab_scanner::scan_raw_msg(std::string_view cat, std::string_view text, bool third) const {
+  if (use_Token)
+    Token_scan_raw_msg(cat, text, third);
+  else
+    SrcMap_scan_raw_msg(cat, text, third);
+}
+
+
+uint32_t Elab_scanner::scan_line() const {
+  if (use_Token)
+    return Token_scan_line();
+  else
+    return SrcMap_scan_line();
+}
+
+void Elab_scanner::dump_token() const {
+  if (use_Token)
+    Token_dump_token();
+  else
+    SrcMap_dump_token();
+}
+
+bool Elab_scanner::scan_prev() {
+  if (use_Token)
+    Token_scan_prev();
+  else
+    SrcMap_scan_prev();
+}
+
 void Elab_scanner::add_token(Token &t) {
+
   if (t.tok == Token_id_nop) {
     token_list_spaced = true;
     I(!trying_merge);
@@ -72,6 +145,7 @@ void Elab_scanner::add_token(Token &t) {
     trying_merge      = false;
     token_list_spaced = false;
     token_list.push_back(t);
+
     return;
   }
 
@@ -101,6 +175,7 @@ void Elab_scanner::add_token(Token &t) {
   } else if (t.tok == Token_id_qmark) {
     if (last_tok.tok == Token_id_alnum) {
       auto txt = last_tok.get_text();
+      // auto txt = t.get_text();
       if (txt.size() && txt[0] == '0') {
         auto last_txt = last_tok.get_text();
         if (last_txt.size() >= 2 && (last_txt[1] == 'b' || last_txt[1] == 'B')) {
@@ -110,6 +185,7 @@ void Elab_scanner::add_token(Token &t) {
       }
     }
   } else if (t.tok == Token_id_alnum) {
+
     if (last_tok.tok == Token_id_pound) {  // #foo
       token_list.back().fuse_token(Token_id_register, t);
       return;
@@ -124,6 +200,7 @@ void Elab_scanner::add_token(Token &t) {
       return;
     } else if (last_tok.tok == Token_id_alnum || last_tok.tok == Token_id_register || last_tok.tok == Token_id_output
                                               || last_tok.tok == Token_id_input || last_tok.tok == Token_id_reference) {  // foo
+
       token_list.back().append_token(t);
       return;
     }
@@ -144,7 +221,131 @@ void Elab_scanner::add_token(Token &t) {
   token_list.push_back(t);
 }
 
-void Elab_scanner::patch_pass(const absl::flat_hash_map<std::string, Token_id> &keywords) {
+void Elab_scanner::SrcMap_fuse_token(SourceMap::ColMapSP &t, Token_id new_tok, const SourceMap::ColMapSP &t2) {
+  I(t->text.data() + t->text.size() == t2->text.data()); // t2 must be continuous (otherwise, create new token)
+  t->tkn_idx = new_tok; // 
+  auto new_len = t->text.size() + t2->text.size(); 
+  t->text = std::string_view{t->text.data(), new_len}; // 
+}
+
+void Elab_scanner::SrcMap_append_token(SourceMap::ColMapSP &t, const SourceMap::ColMapSP &t2) {
+  I(t->text.data() + t->text.size() == t2->text.data()); // t2 must be continuous (otherwise, create new token)
+  auto new_len = t->text.size() + t2->text.size();
+  t->text = std::string_view{t->text.data(), new_len};
+}
+
+void Elab_scanner::SrcMap_adjust_token_size(SourceMap::ColMapSP &t, uint64_t end_pos) {
+  GI(t->tkn_idx != Token_id_nop, end_pos >= t->src_idx); //FIXME->sh: check correctness of pos2 // 
+  auto new_len = end_pos - t->src_idx; 
+  t->text = std::string_view{t->text.data(), new_len}; 
+}
+
+SourceMap::ColMapSP Elab_scanner::SrcMap_clear(SourceMap::ColMapSP &t, uint64_t _pos1, uint32_t _line, std::string_view _text) {
+  SourceMap::ColMapSP t_n = SourceMap::ColMapSP(new SourceMap::ColMap());
+  t_n->tkn_idx   = Token_id_nop;
+  t_n->src_col  = _pos1;
+  t_n->src_idx  = _pos1; //FIXME->sh: you clear the token so the length of the token should be 0, pos2 follows pos1
+  t_n->src_line  = _line;
+  t_n->text  = _text;
+  return t_n;
+}
+
+SourceMap::ColMapSP Elab_scanner::SrcMap_reset(SourceMap::ColMapSP &t, Token_id _tok, uint64_t _pos1, uint32_t _line, std::string_view _text) {
+  SourceMap::ColMapSP t_n = SourceMap::ColMapSP(new SourceMap::ColMap());
+  t_n->tkn_idx   = _tok;
+  t_n->src_col  = _pos1;
+  t_n->src_idx  = _pos1; //FIXME->sh: you reset the token so the length of the token should be 0, pos2 follows pos1
+  t_n->src_line  = _line;
+  t_n->text  = _text;
+  return t_n;
+}
+
+void Elab_scanner::SrcMap_add_token(SourceMap::ColMapSP &t) {
+  if (t->tkn_idx == Token_id_nop) { 
+    token_list_spaced = true;
+    I(!trying_merge);
+    return;
+  }
+
+  if (likely(!trying_merge || token_list_spaced)) {
+    trying_merge      = false;
+    token_list_spaced = false;
+    SrcMap_token_list.push_back(t); 
+    return;
+  }
+
+  trying_merge    = false;
+  SourceMap::ColMapSP &last_tok = SrcMap_token_list.back(); 
+  if (last_tok->tkn_idx == Token_id_or && t->tkn_idx == Token_id_gt) { 
+    SrcMap_fuse_token(SrcMap_token_list.back(), Token_id_pipe, t); 
+    return;
+  } else if (t->tkn_idx == Token_id_eq) {    // <= 
+    if (last_tok->tkn_idx == Token_id_lt) {  // <= 
+      SrcMap_fuse_token(SrcMap_token_list.back(), Token_id_le, t); 
+      return;
+    } else if (last_tok->tkn_idx == Token_id_gt) {  // >=  
+      SrcMap_fuse_token(SrcMap_token_list.back(), Token_id_ge, t); 
+      return;
+    } else if (last_tok->tkn_idx == Token_id_eq) {  // == 
+      SrcMap_fuse_token(SrcMap_token_list.back(), Token_id_same, t); 
+      return;
+    } else if (last_tok->tkn_idx == Token_id_bang) {  // != 
+      SrcMap_fuse_token(SrcMap_token_list.back(), Token_id_diff, t); 
+      return;
+    } else if (last_tok->tkn_idx == Token_id_colon) {  // := 
+      SrcMap_fuse_token(SrcMap_token_list.back(), Token_id_coloneq, t); 
+      return;
+    }
+  } else if (t->tkn_idx == Token_id_qmark) { 
+    if (last_tok->tkn_idx == Token_id_alnum) { 
+      auto txt = last_tok->text; 
+      if (txt.size() && txt[0] == '0') {
+        auto last_txt = last_tok->text; 
+        if (last_txt.size() >= 2 && (last_txt[1] == 'b' || last_txt[1] == 'B')) {
+          SrcMap_fuse_token(SrcMap_token_list.back(), Token_id_alnum, t); 
+          return;
+        }
+      }
+    }
+  } else if (t->tkn_idx == Token_id_alnum) { 
+    if (last_tok->tkn_idx == Token_id_pound) {  // #foo 
+      SrcMap_fuse_token(SrcMap_token_list.back(), Token_id_register, t); 
+      return;
+    } else if (last_tok->tkn_idx == Token_id_percent) {  // %foo 
+      SrcMap_fuse_token(SrcMap_token_list.back(), Token_id_output, t); 
+      return;
+    } else if (last_tok->tkn_idx == Token_id_dollar) {   // $foo 
+      SrcMap_fuse_token(SrcMap_token_list.back(), Token_id_input, t); 
+      return;
+    } else if (last_tok->tkn_idx == Token_id_at) {        // @foo 
+      SrcMap_fuse_token(SrcMap_token_list.back(), Token_id_reference, t); 
+      return;
+    } else if (last_tok->tkn_idx == Token_id_alnum || last_tok->tkn_idx == Token_id_register || last_tok->tkn_idx == Token_id_output 
+                                              || last_tok->tkn_idx == Token_id_input || last_tok->tkn_idx == Token_id_reference) {  // foo 
+      
+      SrcMap_append_token(SrcMap_token_list.back(), t); 
+      return;
+    }
+  } else if (last_tok->tkn_idx == Token_id_at) { 
+    if (t->tkn_idx == Token_id_dollar) {  // @$ 
+      SrcMap_fuse_token(SrcMap_token_list.back(), Token_id_reference, t); 
+      return;
+    } else if (t->tkn_idx == Token_id_pound) {  // @# 
+      SrcMap_fuse_token(SrcMap_token_list.back(), Token_id_reference, t); 
+      return;
+    } else if (t->tkn_idx == Token_id_percent) {  // @% 
+      SrcMap_fuse_token(SrcMap_token_list.back(), Token_id_reference, t); 
+      return;
+    }
+  }
+
+  token_list_spaced = false;
+  SrcMap_token_list.push_back(t); 
+}
+
+
+
+void Elab_scanner::Token_patch_pass(const absl::flat_hash_map<std::string, Token_id> &keywords) {
 
   for (size_t i=0;i<token_list.size();++i) {
     auto &t = token_list[i];
@@ -175,7 +376,37 @@ void Elab_scanner::patch_pass(const absl::flat_hash_map<std::string, Token_id> &
   }
 }
 
-void Elab_scanner::parse_setup(std::string_view filename) {
+
+void Elab_scanner::SrcMap_patch_pass(const absl::flat_hash_map<std::string, Token_id> &keywords) {
+
+  for (size_t i=0;i<SrcMap_token_list.size();++i) { 
+    auto &t = SrcMap_token_list[i]; 
+    if (t->tkn_idx != Token_id_alnum) continue; 
+    I(t->text.size()>0); // at least a character 
+    std::string_view txt = t->text; 
+
+    if (isdigit(txt[0])) {
+      t->tkn_idx = Token_id_num; 
+
+#ifndef NDEBUG
+      // binary accepts ? as part of the numeric constant
+      if (txt.size() > 2 && (txt[1] == 'b' || txt[1] == 'B')) {
+        if ((i+1)<SrcMap_token_list.size()) 
+          I(SrcMap_token_list[i+1]->tkn_idx != Token_id_qmark); 
+      }
+#endif
+
+      continue;
+    }
+
+    auto it = keywords.find(txt);
+    if (it == keywords.end()) continue;
+
+    t->tkn_idx = it->second;
+  }
+}
+
+void Elab_scanner::Token_parse_setup(std::string_view filename) {
   if(memblock_fd==-1) {
     unregister_memblock();
   }
@@ -201,7 +432,35 @@ void Elab_scanner::parse_setup(std::string_view filename) {
   token_list.clear();
 }
 
-void Elab_scanner::parse_setup() {
+void Elab_scanner::SrcMap_parse_setup(std::string_view filename) {
+
+  if(memblock_fd==-1) {
+    unregister_memblock();
+  }
+
+  memblock_fd = open(std::string(filename).c_str(), O_RDONLY);
+  if (memblock_fd < 0) {
+    parser_error("::parse could not open file {}", filename);
+    return;
+  }
+
+  struct stat sb;
+  fstat(memblock_fd, &sb);
+
+  char *b = (char *)mmap(NULL, sb.st_size, PROT_WRITE, MAP_PRIVATE, memblock_fd, 0);
+  if (b == MAP_FAILED) {
+    parser_error("parse mmap failed for file {} with size {}", filename, sb.st_size);
+    return;
+  }
+
+  memblock = std::string_view(b, sb.st_size);
+  buffer_name = filename;
+
+  SrcMap_token_list.clear();
+}
+
+void Elab_scanner::Token_parse_setup() {
+
   if(memblock_fd==-1) {
     unregister_memblock();
   }
@@ -212,12 +471,24 @@ void Elab_scanner::parse_setup() {
   token_list.clear();
 }
 
+void Elab_scanner::SrcMap_parse_setup() {
+
+  if(memblock_fd==-1) {
+    unregister_memblock();
+  }
+
+  memblock_fd = -1;
+  buffer_name = "inline";
+
+  SrcMap_token_list.clear();
+}
+
 static inline bool is_newline(char c) {
   return c == '\n' || c == '\r' || c == '\f';
 }
 
-void Elab_scanner::parse_step() {
 
+void Elab_scanner::Token_parse_step() {
   I(token_list.empty());
 
   token_list.emplace_back();  // bogus zero entry
@@ -233,17 +504,20 @@ void Elab_scanner::parse_step() {
   Token t;
   t.clear(Token_id_nop, 0, std::string_view{&memblock[0],0});
 
+
   bool starting_comment  = false;  // Only for comments to avoid /*/* nested back to back */*/
   bool finishing_comment = false;  // Only for comments to avoid /*/* nested back to back */*/
   for (size_t pos = 0; pos < memblock.size(); pos++) {
     char c = memblock[pos];
 
     t.adjust_token_size(pos);
+
     if (unlikely(is_newline(c))) {
       nlines++;
       if (!in_comment && t.tok != Token_id_nop) {
         add_token(t);
         t.clear(pos, nlines, std::string_view(&memblock[pos],0));
+
         trying_merge = false;
       } else {
         starting_comment      = false;
@@ -344,10 +618,13 @@ void Elab_scanner::parse_step() {
       in_string_pos = true;
     } else {
       Token_id nt = translate[c].tok;//next token
+
       finishing_comment = false;
 
       add_token(t);
+
       t.reset(nt, pos, nlines, std::string_view(&memblock[pos],1));
+
       trying_merge = translate[c].try_merge;
     }
 
@@ -368,6 +645,157 @@ void Elab_scanner::parse_step() {
   scanner_pos = 1;
 }
 
+void Elab_scanner::SrcMap_parse_step() {
+  I(SrcMap_token_list.empty()); 
+  SrcMap_token_list.push_back(SourceMap::ColMapSP(new SourceMap::ColMap())); 
+
+  scanner_pos = 1;            // Skip zero to catch bugs
+
+  int  nlines                = 0;
+  char last_c                = 0;
+  bool in_string_pos         = false;
+  bool in_comment            = false;
+  bool in_singleline_comment = false;
+  int  in_multiline_comment  = 0;  // Nesting support
+
+  SourceMap::ColMapSP t = SourceMap::ColMapSP(new SourceMap::ColMap()); 
+
+  SrcMap_clear(t, Token_id_nop, 0, std::string_view{&memblock[0],0}); 
+
+  bool starting_comment  = false;  // Only for comments to avoid /*/* nested back to back */*/
+  bool finishing_comment = false;  // Only for comments to avoid /*/* nested back to back */*/
+  for (size_t pos = 0; pos < memblock.size(); pos++) {
+    char c = memblock[pos];
+
+    SrcMap_adjust_token_size(t, pos); 
+
+    if (unlikely(is_newline(c))) {
+
+      nlines++;
+      if (!in_comment && t->tkn_idx != Token_id_nop) { 
+        SrcMap_add_token(t); 
+        t = SrcMap_clear(t, pos, nlines, std::string_view(&memblock[pos],0)); 
+        trying_merge = false;
+      } else {
+        starting_comment      = false;
+        finishing_comment     = false;
+        in_singleline_comment = false;
+        in_comment            = in_singleline_comment | in_multiline_comment;
+        if (!in_comment) {
+          if (t->tkn_idx == Token_id_synopsys) { 
+            scan_warn("synopsys directive (most likely ignored)");
+          }
+          SrcMap_add_token(t); 
+          t = SrcMap_clear(t, pos, nlines, std::string_view(&memblock[pos],0)); 
+          trying_merge = false;
+        }
+      }
+      if (in_string_pos) {
+        SrcMap_add_token(t); 
+        t = SrcMap_clear(t, pos, nlines, std::string_view(&memblock[pos],0)); 
+        trying_merge = false;
+        in_string_pos = false;
+      }
+    } else if (unlikely(last_c == '/' && c == '/')) {
+      t->tkn_idx        = Token_id_comment; 
+      trying_merge = false;
+
+      // in the works!!
+      if (!in_comment) {
+        constexpr size_t len1 = std::char_traits<char>::length("synopsys ");
+        size_t           npos = pos + 1;
+        while (memblock[npos] == ' ' && npos < memblock.size()) npos++;
+        if ((npos + len1) < memblock.size()) {
+          if (strncmp(&memblock[npos], "synopsys ", len1) == 0) {
+            t->tkn_idx = Token_id_synopsys; 
+          }
+        }
+      }
+      in_singleline_comment = true;
+      in_comment            = true;
+      assert(!starting_comment);
+      assert(!finishing_comment);
+    } else if (unlikely(!finishing_comment && ((last_c == '/' && c == '*') ||
+                                               (last_c == '(' && c == '*' && (memblock.size() > pos) && memblock[pos + 1] != ')' &&
+                                              SrcMap_token_list.size() && SrcMap_token_list.back()->tkn_idx != Token_id_at)))) { 
+      
+      t->tkn_idx        = Token_id_comment; 
+      trying_merge = false;
+
+      in_multiline_comment++;
+      in_comment       = true;
+      starting_comment = true;
+      assert(!finishing_comment);
+      // The (* foo *) are attributes - not comments - in verilog. Must be handled in the grammar
+    } else if (unlikely(!starting_comment && ((last_c == '*' && c == '/') || (in_comment && last_c == '*' && c == ')')))) {
+      t->tkn_idx        = Token_id_comment; 
+      trying_merge = false;
+
+      in_multiline_comment--;
+      if (in_multiline_comment < 0) {
+        scan_error("{}:{} found end of comment without matching beginning of comment", buffer_name, nlines);
+      } else if (in_multiline_comment == 0) {
+        in_singleline_comment = false;
+        in_comment            = false;
+      }
+      assert(!starting_comment);
+      finishing_comment = true;
+    } else if (unlikely(in_comment)) {
+      starting_comment  = false;
+      finishing_comment = false;
+
+      if (in_singleline_comment) {
+        if(!is_newline(memblock[pos]) && (pos+1)<memblock.size()) {
+          // TODO: Convert this to a word base (not byte based) skip
+          while(!is_newline(memblock[pos+1]) && (pos+3)<memblock.size())
+            pos++;
+        }
+      } else {
+        if(!is_newline(memblock[pos]) && memblock[pos]!='*' && memblock[pos]!='/' && (pos+3)<memblock.size()) {
+          // TODO: Convert this to a word base (not byte based) skip
+          while(!is_newline(memblock[pos+1]) && memblock[pos+1]!='*' && memblock[pos+1]!='/' && (pos+3)<memblock.size())
+            pos++;
+        }
+      }
+
+    } else if (unlikely(in_string_pos)) {
+      if (c == '"' && last_c != '\\') {
+        SrcMap_add_token(t); 
+        t = SrcMap_clear(t, pos, nlines, std::string_view(&memblock[pos],0)); 
+        trying_merge = false;
+        in_string_pos = false;
+      }
+    } else if (unlikely(c == '"' && last_c != '\\')) {
+      SrcMap_add_token(t); 
+      t = SrcMap_reset(t, Token_id_string, pos + 1, nlines, std::string_view(&memblock[pos+1],1)); 
+      trying_merge = false;
+      in_string_pos = true;
+    } else {
+      Token_id nt = translate[c].tok;//next token
+      finishing_comment = false;
+      SrcMap_add_token(t); 
+      t = SrcMap_reset(t, nt, pos, nlines, std::string_view(&memblock[pos],1)); 
+
+      trying_merge = translate[c].try_merge;
+    }
+
+    last_c = c;
+  } //end of token_list building
+  if (t->tkn_idx != Token_id_nop) { 
+    SrcMap_adjust_token_size(t, memblock.size()); 
+    SrcMap_add_token(t);  
+  }
+
+  if (in_multiline_comment) {
+    scan_error("scanner reached end of file with a multi-line comment");
+  }
+
+  elaborate(); //build ast
+
+  scanner_pos = 1;
+}
+
+
 Elab_scanner::Elab_scanner() {
   setup_translate();
   max_errors   = 1;
@@ -380,6 +808,7 @@ Elab_scanner::Elab_scanner() {
 }
 
 void Elab_scanner::unregister_memblock() {
+
   if (memblock_fd==-1)
     return;
 
@@ -395,23 +824,31 @@ Elab_scanner::~Elab_scanner() {
   unregister_memblock();
 }
 
-bool Elab_scanner::scan_next() {
+bool Elab_scanner::Token_scan_next() {
   if (scanner_pos >= token_list.size()) return false;
-
   scanner_pos = scanner_pos + 1;
-
   return true;
 }
 
-bool Elab_scanner::scan_prev() {
+bool Elab_scanner::SrcMap_scan_next() {
+  if (scanner_pos >= SrcMap_token_list.size()) return false; 
+  scanner_pos = scanner_pos + 1;
+  return true;
+}
+
+bool Elab_scanner::Token_scan_prev() {
   if (scanner_pos <= 1) return false;
-
   scanner_pos = scanner_pos - 1;
-
   return true;
 }
 
-void Elab_scanner::scan_format_append(std::string &text) const {
+bool Elab_scanner::SrcMap_scan_prev() {
+  if (scanner_pos <= 1) return false;
+  scanner_pos = scanner_pos - 1;
+  return true;
+}
+
+void Elab_scanner::Token_scan_format_append(std::string &text) const {
   assert(scanner_pos < token_list.size());
   if (scanner_pos > 0) {
     if (token_list[scanner_pos-1].line != token_list[scanner_pos].line) {
@@ -424,15 +861,33 @@ void Elab_scanner::scan_format_append(std::string &text) const {
   absl::StrAppend(&text, token_list[scanner_pos].get_text());
 }
 
-uint32_t Elab_scanner::scan_line() const {
+void Elab_scanner::SrcMap_scan_format_append(std::string &text) const {
+  assert(scanner_pos < SrcMap_token_list.size()); 
+  if (scanner_pos > 0) {
+    if (SrcMap_token_list[scanner_pos-1]->src_line != SrcMap_token_list[scanner_pos]->src_line) { 
+      absl::StrAppend(&text, "\n", SrcMap_token_list[scanner_pos]->text); 
+      return;
+    }
+    absl::StrAppend(&text, " ", SrcMap_token_list[scanner_pos]->text); 
+    return;
+  }
+  absl::StrAppend(&text, SrcMap_token_list[scanner_pos]->text); 
+}
+
+uint32_t Elab_scanner::Token_scan_line() const {
   size_t max_pos = scanner_pos;
   if (max_pos >= token_list.size()) max_pos = token_list.size() - 1;
   return token_list[max_pos].line;
 }
 
+uint32_t Elab_scanner::SrcMap_scan_line() const {
+  size_t max_pos = scanner_pos;
+  if (max_pos >= SrcMap_token_list.size()) max_pos = SrcMap_token_list.size() - 1; 
+  return SrcMap_token_list[max_pos]->src_line; 
+}
+
 void Elab_scanner::lex_error(std::string_view text) {
   // lexer can not look at token list
-
   fmt::print("{}\n", text);
   n_errors++;
   throw std::runtime_error(std::string(text));
@@ -450,7 +905,9 @@ void Elab_scanner::scan_warn_int(std::string_view text) const {
     throw std::runtime_error("too many warnings");
 }
 
-void Elab_scanner::parser_info_int(std::string_view text) const { scan_raw_msg("info", text, true); }
+void Elab_scanner::parser_info_int(std::string_view text) const {
+  scan_raw_msg("info", text, true); 
+}
 
 void Elab_scanner::parser_error_int(std::string_view text) const {
   scan_raw_msg("error", text, false);
@@ -466,8 +923,8 @@ void Elab_scanner::parser_warn_int(std::string_view text) const {
     throw std::runtime_error("too many warnings");
 }
 
-void Elab_scanner::scan_raw_msg(std::string_view cat, std::string_view text, bool third) const {
 
+void Elab_scanner::Token_scan_raw_msg(std::string_view cat, std::string_view text, bool third) const {
   if (token_list.size() <= 1) {
     fmt::print("{}:{}:{} {}: {}\n", buffer_name, 0, 0, cat, text);
     return;
@@ -529,10 +986,78 @@ void Elab_scanner::scan_raw_msg(std::string_view cat, std::string_view text, boo
   fmt::print(third_1 + third_2 + "\n");
 }
 
-void Elab_scanner::dump_token() const {
+void Elab_scanner::SrcMap_scan_raw_msg(std::string_view cat, std::string_view text, bool third) const {
+  if (SrcMap_token_list.size() <= 1) { 
+    fmt::print("{}:{}:{} {}: {}\n", buffer_name, 0, 0, cat, text);
+    return;
+  }
+
+  size_t max_pos = scanner_pos;
+  if (max_pos >= SrcMap_token_list.size() || scanner_pos.value == 0) max_pos = SrcMap_token_list.size() - 1; 
+
+  size_t line_pos_start = 0;
+  for (int i = SrcMap_token_list[max_pos]->src_col; i > 0; i--) { 
+    if (is_newline(memblock[i])) {
+      line_pos_start = i;
+      break;
+    }
+  }
+  size_t line_pos_end = memblock.size();
+  for (size_t i = SrcMap_token_list[max_pos]->src_col; i < memblock.size(); i++) { 
+    if (is_newline(memblock[i])) {
+      line_pos_end = i;
+      break;
+    }
+  }
+
+  auto line = scan_line();
+  int s_col  = SrcMap_token_list[max_pos]->src_col - line_pos_start; 
+  I(s_col>=0);
+  size_t col = s_col;
+
+  std::string line_txt;
+
+  size_t xtra_col = 0;
+  for (size_t i = 0; i < (line_pos_end - line_pos_start); i++) {
+    if (memblock[line_pos_start + i] == '\t') {
+      line_txt += "  ";  // 2 spaces
+      if (i <= col) xtra_col++;
+    } else {
+      line_txt += memblock[line_pos_start + i];
+    }
+  }
+  col += xtra_col;
+
+  fmt::print("{}:{}:{} {}: ", buffer_name, line, col, cat);
+  std::cout << text;  // NOTE: no fmt::print because it can contain {}
+
+  if (!is_newline(memblock[line_pos_start])) std::cout << std::endl;
+
+  assert(line_pos_end > line_pos_start);
+  std::cout << line_txt << "\n";
+  // NOTE: line_pos_start points to the last return
+  // NOTE: no fmt::print because the text can contain {}
+
+  if (!third) return;
+
+  int len = SrcMap_token_list[max_pos]->text.size(); 
+  if ((SrcMap_token_list[max_pos]->src_col + len) > line_pos_end) len = line_pos_end - SrcMap_token_list[max_pos]->src_col; 
+
+  std::string third_1(col, ' ');
+  std::string third_2(len, '^');
+  fmt::print(third_1 + third_2 + "\n");
+}
+
+void Elab_scanner::Token_dump_token() const {
   size_t pos = scanner_pos;
   if (pos >= token_list.size()) pos = token_list.size();
 
   auto &t = token_list[pos];
   fmt::print("tok:{} pos1:{}, pos2:{}, line:{} text:{}\n", t.tok, t.pos1, t.pos2, t.line, t.get_text());
+}
+void Elab_scanner::SrcMap_dump_token() const {
+  size_t pos = scanner_pos;
+  if (pos >= SrcMap_token_list.size()) pos = SrcMap_token_list.size(); 
+  auto &t = SrcMap_token_list[pos];
+  fmt::print("tok:{} pos1:{}, pos2:{}, line:{} text:{}\n", t->tkn_idx, t->src_col, t->src_idx, t->src_line, t->text); 
 }

--- a/elab/encode.h
+++ b/elab/encode.h
@@ -1,0 +1,77 @@
+// :mode=c++:
+/*
+encode.h - c++ wrapper for a base64 encoding algorithm
+
+This is part of the libb64 project, and has been placed in the public domain.
+For details, see http://sourceforge.net/projects/libb64
+*/
+#ifndef BASE64_ENCODE_H
+#define BASE64_ENCODE_H
+
+#include <iostream>
+
+namespace base64
+{
+	extern "C" 
+	{
+		#include "cencode.h"
+	}
+
+	struct encoder
+	{
+		base64_encodestate _state;
+		int _buffersize;
+
+		encoder(int buffersize_in = BUFFERSIZE)
+		: _buffersize(buffersize_in)
+		{}
+
+		int encode(char value_in)
+		{
+			return base64_encode_value(value_in);
+		}
+
+		int encode(const char* code_in, const int length_in, char* plaintext_out)
+		{
+			return base64_encode_block(code_in, length_in, plaintext_out, &_state);
+		}
+
+		int encode_end(char* plaintext_out)
+		{
+			return base64_encode_blockend(plaintext_out, &_state);
+		}
+
+		void encode(std::istream& istream_in, std::ostream& ostream_in)
+		{
+			base64_init_encodestate(&_state);
+			//
+			const int N = _buffersize;
+			char* plaintext = new char[N];
+			char* code = new char[2*N];
+			int plainlength;
+			int codelength;
+
+			do
+			{
+				istream_in.read(plaintext, N);
+				plainlength = istream_in.gcount();
+				//
+				codelength = encode(plaintext, plainlength, code);
+				ostream_in.write(code, codelength);
+			}
+			while (istream_in.good() && plainlength > 0);
+
+			codelength = encode_end(code);
+			ostream_in.write(code, codelength);
+			//
+			base64_init_encodestate(&_state);
+
+			delete [] code;
+			delete [] plaintext;
+		}
+	};
+
+} // namespace base64
+
+#endif // BASE64_ENCODE_H
+

--- a/elab/json.cpp
+++ b/elab/json.cpp
@@ -1,0 +1,1411 @@
+/*
+  Copyright (C) 2011 Joseph A. Adams (joeyadams3.14159@gmail.com)
+  All rights reserved.
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in
+  all copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  THE SOFTWARE.
+*/
+
+#include "json.hpp"
+
+#include <assert.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#ifdef _MSC_VER
+
+#include <stdarg.h>
+#define snprintf c99_snprintf
+
+inline int c99_vsnprintf(char* str, size_t size, const char* format, va_list ap)
+{
+    int count = -1;
+
+    if (size != 0)
+        count = _vsnprintf_s(str, size, _TRUNCATE, format, ap);
+    if (count == -1)
+        count = _vscprintf(format, ap);
+
+    return count;
+}
+
+inline int c99_snprintf(char* str, size_t size, const char* format, ...)
+{
+    int count;
+    va_list ap;
+
+    va_start(ap, format);
+    count = c99_vsnprintf(str, size, format, ap);
+    va_end(ap);
+
+    return count;
+}
+#endif // _MSC_VER
+
+#define out_of_memory() do {                    \
+    fprintf(stderr, "Out of memory.\n");    \
+    exit(EXIT_FAILURE);                     \
+  } while (0)
+
+/* Sadly, strdup is not portable. */
+static char *json_strdup(const char *str)
+{
+  char *ret = (char*) malloc(strlen(str) + 1);
+  if (ret == NULL)
+    out_of_memory();
+  strcpy(ret, str);
+  return ret;
+}
+
+/* String buffer */
+
+typedef struct
+{
+  char *cur;
+  char *end;
+  char *start;
+} SB;
+
+static void sb_init(SB *sb)
+{
+  sb->start = (char*) malloc(17);
+  if (sb->start == NULL)
+    out_of_memory();
+  sb->cur = sb->start;
+  sb->end = sb->start + 16;
+}
+
+/* sb and need may be evaluated multiple times. */
+#define sb_need(sb, need) do {                  \
+    if ((sb)->end - (sb)->cur < (need))     \
+      sb_grow(sb, need);                  \
+  } while (0)
+
+static void sb_grow(SB *sb, int need)
+{
+  size_t length = sb->cur - sb->start;
+  size_t alloc = sb->end - sb->start;
+
+  do {
+    alloc *= 2;
+  } while (alloc < length + need);
+
+  sb->start = (char*) realloc(sb->start, alloc + 1);
+  if (sb->start == NULL)
+    out_of_memory();
+  sb->cur = sb->start + length;
+  sb->end = sb->start + alloc;
+}
+
+static void sb_put(SB *sb, const char *bytes, int count)
+{
+  sb_need(sb, count);
+  memcpy(sb->cur, bytes, count);
+  sb->cur += count;
+}
+
+#define sb_putc(sb, c) do {         \
+    if ((sb)->cur >= (sb)->end) \
+      sb_grow(sb, 1);         \
+    *(sb)->cur++ = (c);         \
+  } while (0)
+
+static void sb_puts(SB *sb, const char *str)
+{
+  sb_put(sb, str, strlen(str));
+}
+
+static char *sb_finish(SB *sb)
+{
+  *sb->cur = 0;
+  assert(sb->start <= sb->cur && strlen(sb->start) == (size_t)(sb->cur - sb->start));
+  return sb->start;
+}
+
+static void sb_free(SB *sb)
+{
+  free(sb->start);
+}
+
+/*
+ * Unicode helper functions
+ *
+ * These are taken from the ccan/charset module and customized a bit.
+ * Putting them here means the compiler can (choose to) inline them,
+ * and it keeps ccan/json from having a dependency.
+ */
+
+/*
+ * Type for Unicode codepoints.
+ * We need our own because wchar_t might be 16 bits.
+ */
+typedef uint32_t uchar_t;
+
+/*
+ * Validate a single UTF-8 character starting at @s.
+ * The string must be null-terminated.
+ *
+ * If it's valid, return its length (1 thru 4).
+ * If it's invalid or clipped, return 0.
+ *
+ * This function implements the syntax given in RFC3629, which is
+ * the same as that given in The Unicode Standard, Version 6.0.
+ *
+ * It has the following properties:
+ *
+ *  * All codepoints U+0000..U+10FFFF may be encoded,
+ *    except for U+D800..U+DFFF, which are reserved
+ *    for UTF-16 surrogate pair encoding.
+ *  * UTF-8 byte sequences longer than 4 bytes are not permitted,
+ *    as they exceed the range of Unicode.
+ *  * The sixty-six Unicode "non-characters" are permitted
+ *    (namely, U+FDD0..U+FDEF, U+xxFFFE, and U+xxFFFF).
+ */
+static int utf8_validate_cz(const char *s)
+{
+  unsigned char c = *s++;
+
+  if (c <= 0x7F) {        /* 00..7F */
+    return 1;
+  } else if (c <= 0xC1) { /* 80..C1 */
+    /* Disallow overlong 2-byte sequence. */
+    return 0;
+  } else if (c <= 0xDF) { /* C2..DF */
+    /* Make sure subsequent byte is in the range 0x80..0xBF. */
+    if (((unsigned char)*s++ & 0xC0) != 0x80)
+      return 0;
+
+    return 2;
+  } else if (c <= 0xEF) { /* E0..EF */
+    /* Disallow overlong 3-byte sequence. */
+    if (c == 0xE0 && (unsigned char)*s < 0xA0)
+      return 0;
+
+    /* Disallow U+D800..U+DFFF. */
+    if (c == 0xED && (unsigned char)*s > 0x9F)
+      return 0;
+
+    /* Make sure subsequent bytes are in the range 0x80..0xBF. */
+    if (((unsigned char)*s++ & 0xC0) != 0x80)
+      return 0;
+    if (((unsigned char)*s++ & 0xC0) != 0x80)
+      return 0;
+
+    return 3;
+  } else if (c <= 0xF4) { /* F0..F4 */
+    /* Disallow overlong 4-byte sequence. */
+    if (c == 0xF0 && (unsigned char)*s < 0x90)
+      return 0;
+
+    /* Disallow codepoints beyond U+10FFFF. */
+    if (c == 0xF4 && (unsigned char)*s > 0x8F)
+      return 0;
+
+    /* Make sure subsequent bytes are in the range 0x80..0xBF. */
+    if (((unsigned char)*s++ & 0xC0) != 0x80)
+      return 0;
+    if (((unsigned char)*s++ & 0xC0) != 0x80)
+      return 0;
+    if (((unsigned char)*s++ & 0xC0) != 0x80)
+      return 0;
+
+    return 4;
+  } else {                /* F5..FF */
+    return 0;
+  }
+}
+
+/* Validate a null-terminated UTF-8 string. */
+static bool utf8_validate(const char *s)
+{
+  int len;
+
+  for (; *s != 0; s += len) {
+    len = utf8_validate_cz(s);
+    if (len == 0)
+      return false;
+  }
+
+  return true;
+}
+
+/*
+ * Read a single UTF-8 character starting at @s,
+ * returning the length, in bytes, of the character read.
+ *
+ * This function assumes input is valid UTF-8,
+ * and that there are enough characters in front of @s.
+ */
+static int utf8_read_char(const char *s, uchar_t *out)
+{
+  const unsigned char *c = (const unsigned char*) s;
+
+  assert(utf8_validate_cz(s));
+
+  if (c[0] <= 0x7F) {
+    /* 00..7F */
+    *out = c[0];
+    return 1;
+  } else if (c[0] <= 0xDF) {
+    /* C2..DF (unless input is invalid) */
+    *out = ((uchar_t)c[0] & 0x1F) << 6 |
+           ((uchar_t)c[1] & 0x3F);
+    return 2;
+  } else if (c[0] <= 0xEF) {
+    /* E0..EF */
+    *out = ((uchar_t)c[0] &  0xF) << 12 |
+           ((uchar_t)c[1] & 0x3F) << 6  |
+           ((uchar_t)c[2] & 0x3F);
+    return 3;
+  } else {
+    /* F0..F4 (unless input is invalid) */
+    *out = ((uchar_t)c[0] &  0x7) << 18 |
+           ((uchar_t)c[1] & 0x3F) << 12 |
+           ((uchar_t)c[2] & 0x3F) << 6  |
+           ((uchar_t)c[3] & 0x3F);
+    return 4;
+  }
+}
+
+/*
+ * Write a single UTF-8 character to @s,
+ * returning the length, in bytes, of the character written.
+ *
+ * @unicode must be U+0000..U+10FFFF, but not U+D800..U+DFFF.
+ *
+ * This function will write up to 4 bytes to @out.
+ */
+static int utf8_write_char(uchar_t unicode, char *out)
+{
+  unsigned char *o = (unsigned char*) out;
+
+  assert(unicode <= 0x10FFFF && !(unicode >= 0xD800 && unicode <= 0xDFFF));
+
+  if (unicode <= 0x7F) {
+    /* U+0000..U+007F */
+    *o++ = unicode;
+    return 1;
+  } else if (unicode <= 0x7FF) {
+    /* U+0080..U+07FF */
+    *o++ = 0xC0 | unicode >> 6;
+    *o++ = 0x80 | (unicode & 0x3F);
+    return 2;
+  } else if (unicode <= 0xFFFF) {
+    /* U+0800..U+FFFF */
+    *o++ = 0xE0 | unicode >> 12;
+    *o++ = 0x80 | (unicode >> 6 & 0x3F);
+    *o++ = 0x80 | (unicode & 0x3F);
+    return 3;
+  } else {
+    /* U+10000..U+10FFFF */
+    *o++ = 0xF0 | unicode >> 18;
+    *o++ = 0x80 | (unicode >> 12 & 0x3F);
+    *o++ = 0x80 | (unicode >> 6 & 0x3F);
+    *o++ = 0x80 | (unicode & 0x3F);
+    return 4;
+  }
+}
+
+/*
+ * Compute the Unicode codepoint of a UTF-16 surrogate pair.
+ *
+ * @uc should be 0xD800..0xDBFF, and @lc should be 0xDC00..0xDFFF.
+ * If they aren't, this function returns false.
+ */
+static bool from_surrogate_pair(uint16_t uc, uint16_t lc, uchar_t *unicode)
+{
+  if (uc >= 0xD800 && uc <= 0xDBFF && lc >= 0xDC00 && lc <= 0xDFFF) {
+    *unicode = 0x10000 + ((((uchar_t)uc & 0x3FF) << 10) | (lc & 0x3FF));
+    return true;
+  } else {
+    return false;
+  }
+}
+
+/*
+ * Construct a UTF-16 surrogate pair given a Unicode codepoint.
+ *
+ * @unicode must be U+10000..U+10FFFF.
+ */
+static void to_surrogate_pair(uchar_t unicode, uint16_t *uc, uint16_t *lc)
+{
+  uchar_t n;
+
+  assert(unicode >= 0x10000 && unicode <= 0x10FFFF);
+
+  n = unicode - 0x10000;
+  *uc = ((n >> 10) & 0x3FF) | 0xD800;
+  *lc = (n & 0x3FF) | 0xDC00;
+}
+
+#define is_space(c) ((c) == '\t' || (c) == '\n' || (c) == '\r' || (c) == ' ')
+#define is_digit(c) ((c) >= '0' && (c) <= '9')
+
+static bool parse_value     (const char **sp, JsonNode        **out);
+static bool parse_string    (const char **sp, char            **out);
+static bool parse_number    (const char **sp, double           *out);
+static bool parse_array     (const char **sp, JsonNode        **out);
+static bool parse_object    (const char **sp, JsonNode        **out);
+static bool parse_hex16     (const char **sp, uint16_t         *out);
+
+static bool expect_literal  (const char **sp, const char *str);
+static void skip_space      (const char **sp);
+
+static void emit_value              (SB *out, const JsonNode *node);
+static void emit_value_indented     (SB *out, const JsonNode *node, const char *space, int indent_level);
+static void emit_string             (SB *out, const char *str);
+static void emit_number             (SB *out, double num);
+static void emit_array              (SB *out, const JsonNode *array);
+static void emit_array_indented     (SB *out, const JsonNode *array, const char *space, int indent_level);
+static void emit_object             (SB *out, const JsonNode *object);
+static void emit_object_indented    (SB *out, const JsonNode *object, const char *space, int indent_level);
+
+static int write_hex16(char *out, uint16_t val);
+
+static JsonNode *mknode(JsonTag tag);
+static void append_node(JsonNode *parent, JsonNode *child);
+static void prepend_node(JsonNode *parent, JsonNode *child);
+static void append_member(JsonNode *object, char *key, JsonNode *value);
+
+/* Assertion-friendly validity checks */
+static bool tag_is_valid(unsigned int tag);
+static bool number_is_valid(const char *num);
+
+JsonNode *json_decode(const char *json)
+{
+  const char *s = json;
+  JsonNode *ret;
+
+  skip_space(&s);
+  if (!parse_value(&s, &ret))
+    return NULL;
+
+  skip_space(&s);
+  if (*s != 0) {
+    json_delete(ret);
+    return NULL;
+  }
+
+  return ret;
+}
+
+char *json_encode(const JsonNode *node)
+{
+  return json_stringify(node, NULL);
+}
+
+char *json_encode_string(const char *str)
+{
+  SB sb;
+  sb_init(&sb);
+
+  emit_string(&sb, str);
+
+  return sb_finish(&sb);
+}
+
+char *json_stringify(const JsonNode *node, const char *space)
+{
+  SB sb;
+  sb_init(&sb);
+
+  if (space != NULL)
+    emit_value_indented(&sb, node, space, 0);
+  else
+    emit_value(&sb, node);
+
+  return sb_finish(&sb);
+}
+
+void json_delete(JsonNode *node)
+{
+  if (node != NULL) {
+    json_remove_from_parent(node);
+
+    switch (node->tag) {
+      case JSON_STRING:
+        free(node->string_);
+        break;
+      case JSON_ARRAY:
+      case JSON_OBJECT:
+      {
+        JsonNode *child, *next;
+        for (child = node->children.head; child != NULL; child = next) {
+          next = child->next;
+          json_delete(child);
+        }
+        break;
+      }
+      default:;
+    }
+
+    free(node);
+  }
+}
+
+bool json_validate(const char *json)
+{
+  const char *s = json;
+
+  skip_space(&s);
+  if (!parse_value(&s, NULL))
+    return false;
+
+  skip_space(&s);
+  if (*s != 0)
+    return false;
+
+  return true;
+}
+
+JsonNode *json_find_element(JsonNode *array, int index)
+{
+  JsonNode *element;
+  int i = 0;
+
+  if (array == NULL || array->tag != JSON_ARRAY)
+    return NULL;
+
+  json_foreach(element, array) {
+    if (i == index)
+      return element;
+    i++;
+  }
+
+  return NULL;
+}
+
+JsonNode *json_find_member(JsonNode *object, const char *name)
+{
+  JsonNode *member;
+
+  if (object == NULL || object->tag != JSON_OBJECT)
+    return NULL;
+
+  json_foreach(member, object)
+    if (strcmp(member->key, name) == 0)
+      return member;
+
+  return NULL;
+}
+
+JsonNode *json_first_child(const JsonNode *node)
+{
+  if (node != NULL && (node->tag == JSON_ARRAY || node->tag == JSON_OBJECT))
+    return node->children.head;
+  return NULL;
+}
+
+static JsonNode *mknode(JsonTag tag)
+{
+  JsonNode *ret = (JsonNode*) calloc(1, sizeof(JsonNode));
+  if (ret == NULL)
+    out_of_memory();
+  ret->tag = tag;
+  return ret;
+}
+
+JsonNode *json_mknull(void)
+{
+  return mknode(JSON_NULL);
+}
+
+JsonNode *json_mkbool(bool b)
+{
+  JsonNode *ret = mknode(JSON_BOOL);
+  ret->bool_ = b;
+  return ret;
+}
+
+static JsonNode *mkstring(char *s)
+{
+  JsonNode *ret = mknode(JSON_STRING);
+  ret->string_ = s;
+  return ret;
+}
+
+JsonNode *json_mkstring(const char *s)
+{
+  return mkstring(json_strdup(s));
+}
+
+JsonNode *json_mknumber(double n)
+{
+  JsonNode *node = mknode(JSON_NUMBER);
+  node->number_ = n;
+  return node;
+}
+
+JsonNode *json_mkarray(void)
+{
+  return mknode(JSON_ARRAY);
+}
+
+JsonNode *json_mkobject(void)
+{
+  return mknode(JSON_OBJECT);
+}
+
+static void append_node(JsonNode *parent, JsonNode *child)
+{
+  child->parent = parent;
+  child->prev = parent->children.tail;
+  child->next = NULL;
+
+  if (parent->children.tail != NULL)
+    parent->children.tail->next = child;
+  else
+    parent->children.head = child;
+  parent->children.tail = child;
+}
+
+static void prepend_node(JsonNode *parent, JsonNode *child)
+{
+  child->parent = parent;
+  child->prev = NULL;
+  child->next = parent->children.head;
+
+  if (parent->children.head != NULL)
+    parent->children.head->prev = child;
+  else
+    parent->children.tail = child;
+  parent->children.head = child;
+}
+
+static void append_member(JsonNode *object, char *key, JsonNode *value)
+{
+  value->key = key;
+  append_node(object, value);
+}
+
+void json_append_element(JsonNode *array, JsonNode *element)
+{
+  assert(array->tag == JSON_ARRAY);
+  assert(element->parent == NULL);
+
+  append_node(array, element);
+}
+
+void json_prepend_element(JsonNode *array, JsonNode *element)
+{
+  assert(array->tag == JSON_ARRAY);
+  assert(element->parent == NULL);
+
+  prepend_node(array, element);
+}
+
+void json_append_member(JsonNode *object, const char *key, JsonNode *value)
+{
+  assert(object->tag == JSON_OBJECT);
+  assert(value->parent == NULL);
+
+  append_member(object, json_strdup(key), value);
+}
+
+void json_prepend_member(JsonNode *object, const char *key, JsonNode *value)
+{
+  assert(object->tag == JSON_OBJECT);
+  assert(value->parent == NULL);
+
+  value->key = json_strdup(key);
+  prepend_node(object, value);
+}
+
+void json_remove_from_parent(JsonNode *node)
+{
+  JsonNode *parent = node->parent;
+
+  if (parent != NULL) {
+    if (node->prev != NULL)
+      node->prev->next = node->next;
+    else
+      parent->children.head = node->next;
+    if (node->next != NULL)
+      node->next->prev = node->prev;
+    else
+      parent->children.tail = node->prev;
+
+    free(node->key);
+
+    node->parent = NULL;
+    node->prev = node->next = NULL;
+    node->key = NULL;
+  }
+}
+
+static bool parse_value(const char **sp, JsonNode **out)
+{
+  const char *s = *sp;
+
+  switch (*s) {
+    case 'n':
+      if (expect_literal(&s, "null")) {
+        if (out)
+          *out = json_mknull();
+        *sp = s;
+        return true;
+      }
+      return false;
+
+    case 'f':
+      if (expect_literal(&s, "false")) {
+        if (out)
+          *out = json_mkbool(false);
+        *sp = s;
+        return true;
+      }
+      return false;
+
+    case 't':
+      if (expect_literal(&s, "true")) {
+        if (out)
+          *out = json_mkbool(true);
+        *sp = s;
+        return true;
+      }
+      return false;
+
+    case '"': {
+      char *str;
+      if (parse_string(&s, out ? &str : NULL)) {
+        if (out)
+          *out = mkstring(str);
+        *sp = s;
+        return true;
+      }
+      return false;
+    }
+
+    case '[':
+      if (parse_array(&s, out)) {
+        *sp = s;
+        return true;
+      }
+      return false;
+
+    case '{':
+      if (parse_object(&s, out)) {
+        *sp = s;
+        return true;
+      }
+      return false;
+
+    default: {
+      double num;
+      if (parse_number(&s, out ? &num : NULL)) {
+        if (out)
+          *out = json_mknumber(num);
+        *sp = s;
+        return true;
+      }
+      return false;
+    }
+  }
+}
+
+static bool parse_array(const char **sp, JsonNode **out)
+{
+  const char *s = *sp;
+  JsonNode *ret = out ? json_mkarray() : NULL;
+  JsonNode *element;
+
+  if (*s++ != '[')
+    goto failure;
+  skip_space(&s);
+
+  if (*s == ']') {
+    s++;
+    goto success;
+  }
+
+  for (;;) {
+    if (!parse_value(&s, out ? &element : NULL))
+      goto failure;
+    skip_space(&s);
+
+    if (out)
+      json_append_element(ret, element);
+
+    if (*s == ']') {
+      s++;
+      goto success;
+    }
+
+    if (*s++ != ',')
+      goto failure;
+    skip_space(&s);
+  }
+
+success:
+  *sp = s;
+  if (out)
+    *out = ret;
+  return true;
+
+failure:
+  json_delete(ret);
+  return false;
+}
+
+static bool parse_object(const char **sp, JsonNode **out)
+{
+  const char *s = *sp;
+  JsonNode *ret = out ? json_mkobject() : NULL;
+  char *key;
+  JsonNode *value;
+
+  if (*s++ != '{')
+    goto failure;
+  skip_space(&s);
+
+  if (*s == '}') {
+    s++;
+    goto success;
+  }
+
+  for (;;) {
+    if (!parse_string(&s, out ? &key : NULL))
+      goto failure;
+    skip_space(&s);
+
+    if (*s++ != ':')
+      goto failure_free_key;
+    skip_space(&s);
+
+    if (!parse_value(&s, out ? &value : NULL))
+      goto failure_free_key;
+    skip_space(&s);
+
+    if (out)
+      append_member(ret, key, value);
+
+    if (*s == '}') {
+      s++;
+      goto success;
+    }
+
+    if (*s++ != ',')
+      goto failure;
+    skip_space(&s);
+  }
+
+success:
+  *sp = s;
+  if (out)
+    *out = ret;
+  return true;
+
+failure_free_key:
+  if (out)
+    free(key);
+failure:
+  json_delete(ret);
+  return false;
+}
+
+bool parse_string(const char **sp, char **out)
+{
+  const char *s = *sp;
+  SB sb = {};
+  char throwaway_buffer[4];
+    /* enough space for a UTF-8 character */
+  char *b;
+
+  if (*s++ != '"')
+    return false;
+
+  if (out) {
+    sb_init(&sb);
+    sb_need(&sb, 4);
+    b = sb.cur;
+  } else {
+    b = throwaway_buffer;
+  }
+
+  while (*s != '"') {
+    unsigned char c = *s++;
+
+    /* Parse next character, and write it to b. */
+    if (c == '\\') {
+      c = *s++;
+      switch (c) {
+        case '"':
+        case '\\':
+        case '/':
+          *b++ = c;
+          break;
+        case 'b':
+          *b++ = '\b';
+          break;
+        case 'f':
+          *b++ = '\f';
+          break;
+        case 'n':
+          *b++ = '\n';
+          break;
+        case 'r':
+          *b++ = '\r';
+          break;
+        case 't':
+          *b++ = '\t';
+          break;
+        case 'u':
+        {
+          uint16_t uc, lc;
+          uchar_t unicode;
+
+          if (!parse_hex16(&s, &uc))
+            goto failed;
+
+          if (uc >= 0xD800 && uc <= 0xDFFF) {
+            /* Handle UTF-16 surrogate pair. */
+            if (*s++ != '\\' || *s++ != 'u' || !parse_hex16(&s, &lc))
+              goto failed; /* Incomplete surrogate pair. */
+            if (!from_surrogate_pair(uc, lc, &unicode))
+              goto failed; /* Invalid surrogate pair. */
+          } else if (uc == 0) {
+            /* Disallow "\u0000". */
+            goto failed;
+          } else {
+            unicode = uc;
+          }
+
+          b += utf8_write_char(unicode, b);
+          break;
+        }
+        default:
+          /* Invalid escape */
+          goto failed;
+      }
+    } else if (c <= 0x1F) {
+      /* Control characters are not allowed in string literals. */
+      goto failed;
+    } else {
+      /* Validate and echo a UTF-8 character. */
+      int len;
+
+      s--;
+      len = utf8_validate_cz(s);
+      if (len == 0)
+        goto failed; /* Invalid UTF-8 character. */
+
+      while (len--)
+        *b++ = *s++;
+    }
+
+    /*
+     * Update sb to know about the new bytes,
+     * and set up b to write another character.
+     */
+    if (out) {
+      sb.cur = b;
+      sb_need(&sb, 4);
+      b = sb.cur;
+    } else {
+      b = throwaway_buffer;
+    }
+  }
+  s++;
+
+  if (out)
+    *out = sb_finish(&sb);
+  *sp = s;
+  return true;
+
+failed:
+  if (out)
+    sb_free(&sb);
+  return false;
+}
+
+/*
+ * The JSON spec says that a number shall follow this precise pattern
+ * (spaces and quotes added for readability):
+ *   '-'? (0 | [1-9][0-9]*) ('.' [0-9]+)? ([Ee] [+-]? [0-9]+)?
+ *
+ * However, some JSON parsers are more liberal.  For instance, PHP accepts
+ * '.5' and '1.'.  JSON.parse accepts '+3'.
+ *
+ * This function takes the strict approach.
+ */
+bool parse_number(const char **sp, double *out)
+{
+  const char *s = *sp;
+
+  /* '-'? */
+  if (*s == '-')
+    s++;
+
+  /* (0 | [1-9][0-9]*) */
+  if (*s == '0') {
+    s++;
+  } else {
+    if (!is_digit(*s))
+      return false;
+    do {
+      s++;
+    } while (is_digit(*s));
+  }
+
+  /* ('.' [0-9]+)? */
+  if (*s == '.') {
+    s++;
+    if (!is_digit(*s))
+      return false;
+    do {
+      s++;
+    } while (is_digit(*s));
+  }
+
+  /* ([Ee] [+-]? [0-9]+)? */
+  if (*s == 'E' || *s == 'e') {
+    s++;
+    if (*s == '+' || *s == '-')
+      s++;
+    if (!is_digit(*s))
+      return false;
+    do {
+      s++;
+    } while (is_digit(*s));
+  }
+
+  if (out)
+    *out = strtod(*sp, NULL);
+
+  *sp = s;
+  return true;
+}
+
+static void skip_space(const char **sp)
+{
+  const char *s = *sp;
+  while (is_space(*s))
+    s++;
+  *sp = s;
+}
+
+static void emit_value(SB *out, const JsonNode *node)
+{
+  assert(tag_is_valid(node->tag));
+  switch (node->tag) {
+    case JSON_NULL:
+      sb_puts(out, "null");
+      break;
+    case JSON_BOOL:
+      sb_puts(out, node->bool_ ? "true" : "false");
+      break;
+    case JSON_STRING:
+      emit_string(out, node->string_);
+      break;
+    case JSON_NUMBER:
+      emit_number(out, node->number_);
+      break;
+    case JSON_ARRAY:
+      emit_array(out, node);
+      break;
+    case JSON_OBJECT:
+      emit_object(out, node);
+      break;
+    default:
+      assert(false);
+  }
+}
+
+void emit_value_indented(SB *out, const JsonNode *node, const char *space, int indent_level)
+{
+  assert(tag_is_valid(node->tag));
+  switch (node->tag) {
+    case JSON_NULL:
+      sb_puts(out, "null");
+      break;
+    case JSON_BOOL:
+      sb_puts(out, node->bool_ ? "true" : "false");
+      break;
+    case JSON_STRING:
+      emit_string(out, node->string_);
+      break;
+    case JSON_NUMBER:
+      emit_number(out, node->number_);
+      break;
+    case JSON_ARRAY:
+      emit_array_indented(out, node, space, indent_level);
+      break;
+    case JSON_OBJECT:
+      emit_object_indented(out, node, space, indent_level);
+      break;
+    default:
+      assert(false);
+  }
+}
+
+static void emit_array(SB *out, const JsonNode *array)
+{
+  const JsonNode *element;
+
+  sb_putc(out, '[');
+  json_foreach(element, array) {
+    emit_value(out, element);
+    if (element->next != NULL)
+      sb_putc(out, ',');
+  }
+  sb_putc(out, ']');
+}
+
+static void emit_array_indented(SB *out, const JsonNode *array, const char *space, int indent_level)
+{
+  const JsonNode *element = array->children.head;
+  int i;
+
+  if (element == NULL) {
+    sb_puts(out, "[]");
+    return;
+  }
+
+  sb_puts(out, "[\n");
+  while (element != NULL) {
+    for (i = 0; i < indent_level + 1; i++)
+      sb_puts(out, space);
+    emit_value_indented(out, element, space, indent_level + 1);
+
+    element = element->next;
+    sb_puts(out, element != NULL ? ",\n" : "\n");
+  }
+  for (i = 0; i < indent_level; i++)
+    sb_puts(out, space);
+  sb_putc(out, ']');
+}
+
+static void emit_object(SB *out, const JsonNode *object)
+{
+  const JsonNode *member;
+
+  sb_putc(out, '{');
+  json_foreach(member, object) {
+    emit_string(out, member->key);
+    sb_putc(out, ':');
+    emit_value(out, member);
+    if (member->next != NULL)
+      sb_putc(out, ',');
+  }
+  sb_putc(out, '}');
+}
+
+static void emit_object_indented(SB *out, const JsonNode *object, const char *space, int indent_level)
+{
+  const JsonNode *member = object->children.head;
+  int i;
+
+  if (member == NULL) {
+    sb_puts(out, "{}");
+    return;
+  }
+
+  sb_puts(out, "{\n");
+  while (member != NULL) {
+    for (i = 0; i < indent_level + 1; i++)
+      sb_puts(out, space);
+    emit_string(out, member->key);
+    sb_puts(out, ": ");
+    emit_value_indented(out, member, space, indent_level + 1);
+
+    member = member->next;
+    sb_puts(out, member != NULL ? ",\n" : "\n");
+  }
+  for (i = 0; i < indent_level; i++)
+    sb_puts(out, space);
+  sb_putc(out, '}');
+}
+
+void emit_string(SB *out, const char *str)
+{
+  bool escape_unicode = false;
+  const char *s = str;
+  char *b;
+
+  assert(utf8_validate(str));
+
+  /*
+   * 14 bytes is enough space to write up to two
+   * \uXXXX escapes and two quotation marks.
+   */
+  sb_need(out, 14);
+  b = out->cur;
+
+  *b++ = '"';
+  while (*s != 0) {
+    unsigned char c = *s++;
+
+    /* Encode the next character, and write it to b. */
+    switch (c) {
+      case '"':
+        *b++ = '\\';
+        *b++ = '"';
+        break;
+      case '\\':
+        *b++ = '\\';
+        *b++ = '\\';
+        break;
+      case '\b':
+        *b++ = '\\';
+        *b++ = 'b';
+        break;
+      case '\f':
+        *b++ = '\\';
+        *b++ = 'f';
+        break;
+      case '\n':
+        *b++ = '\\';
+        *b++ = 'n';
+        break;
+      case '\r':
+        *b++ = '\\';
+        *b++ = 'r';
+        break;
+      case '\t':
+        *b++ = '\\';
+        *b++ = 't';
+        break;
+      default: {
+        int len;
+
+        s--;
+        len = utf8_validate_cz(s);
+
+        if (len == 0) {
+          /*
+           * Handle invalid UTF-8 character gracefully in production
+           * by writing a replacement character (U+FFFD)
+           * and skipping a single byte.
+           *
+           * This should never happen when assertions are enabled
+           * due to the assertion at the beginning of this function.
+           */
+          assert(false);
+          if (escape_unicode) {
+            strcpy(b, "\\uFFFD");
+            b += 6;
+          } else {
+            *b++ = 0xEFu;
+            *b++ = 0xBFu;
+            *b++ = 0xBDu;
+          }
+          s++;
+        } else if (c < 0x1F || (c >= 0x80 && escape_unicode)) {
+          /* Encode using \u.... */
+          uint32_t unicode;
+
+          s += utf8_read_char(s, &unicode);
+
+          if (unicode <= 0xFFFF) {
+            *b++ = '\\';
+            *b++ = 'u';
+            b += write_hex16(b, unicode);
+          } else {
+            /* Produce a surrogate pair. */
+            uint16_t uc, lc;
+            assert(unicode <= 0x10FFFF);
+            to_surrogate_pair(unicode, &uc, &lc);
+            *b++ = '\\';
+            *b++ = 'u';
+            b += write_hex16(b, uc);
+            *b++ = '\\';
+            *b++ = 'u';
+            b += write_hex16(b, lc);
+          }
+        } else {
+          /* Write the character directly. */
+          while (len--)
+            *b++ = *s++;
+        }
+
+        break;
+      }
+    }
+
+    /*
+     * Update *out to know about the new bytes,
+     * and set up b to write another encoded character.
+     */
+    out->cur = b;
+    sb_need(out, 14);
+    b = out->cur;
+  }
+  *b++ = '"';
+
+  out->cur = b;
+}
+
+static void emit_number(SB *out, double num)
+{
+  /*
+   * This isn't exactly how JavaScript renders numbers,
+   * but it should produce valid JSON for reasonable numbers
+   * preserve precision well enough, and avoid some oddities
+   * like 0.3 -> 0.299999999999999988898 .
+   */
+  char buf[64];
+  sprintf(buf, "%.16g", num);
+
+  if (number_is_valid(buf))
+    sb_puts(out, buf);
+  else
+    sb_puts(out, "null");
+}
+
+static bool tag_is_valid(unsigned int tag)
+{
+  return (/* tag >= JSON_NULL && */ tag <= JSON_OBJECT);
+}
+
+static bool number_is_valid(const char *num)
+{
+  return (parse_number(&num, NULL) && *num == '\0');
+}
+
+static bool expect_literal(const char **sp, const char *str)
+{
+  const char *s = *sp;
+
+  while (*str != '\0')
+    if (*s++ != *str++)
+      return false;
+
+  *sp = s;
+  return true;
+}
+
+/*
+ * Parses exactly 4 hex characters (capital or lowercase).
+ * Fails if any input chars are not [0-9A-Fa-f].
+ */
+static bool parse_hex16(const char **sp, uint16_t *out)
+{
+  const char *s = *sp;
+  uint16_t ret = 0;
+  uint16_t i;
+  uint16_t tmp;
+  char c;
+
+  for (i = 0; i < 4; i++) {
+    c = *s++;
+    if (c >= '0' && c <= '9')
+      tmp = c - '0';
+    else if (c >= 'A' && c <= 'F')
+      tmp = c - 'A' + 10;
+    else if (c >= 'a' && c <= 'f')
+      tmp = c - 'a' + 10;
+    else
+      return false;
+
+    ret <<= 4;
+    ret += tmp;
+  }
+
+  if (out)
+    *out = ret;
+  *sp = s;
+  return true;
+}
+
+/*
+ * Encodes a 16-bit number into hexadecimal,
+ * writing exactly 4 hex chars.
+ */
+static int write_hex16(char *out, uint16_t val)
+{
+  const char *hex = "0123456789ABCDEF";
+
+  *out++ = hex[(val >> 12) & 0xF];
+  *out++ = hex[(val >> 8)  & 0xF];
+  *out++ = hex[(val >> 4)  & 0xF];
+  *out++ = hex[ val        & 0xF];
+
+  return 4;
+}
+
+bool json_check(const JsonNode *node, char errmsg[256])
+{
+  #define problem(...) do { \
+      if (errmsg != NULL) \
+        snprintf(errmsg, 256, __VA_ARGS__); \
+      return false; \
+    } while (0)
+
+  if (node->key != NULL && !utf8_validate(node->key))
+    problem("key contains invalid UTF-8");
+
+  if (!tag_is_valid(node->tag))
+    problem("tag is invalid (%u)", node->tag);
+
+  if (node->tag == JSON_BOOL) {
+    if (node->bool_ != false && node->bool_ != true)
+      problem("bool_ is neither false (%d) nor true (%d)", (int)false, (int)true);
+  } else if (node->tag == JSON_STRING) {
+    if (node->string_ == NULL)
+      problem("string_ is NULL");
+    if (!utf8_validate(node->string_))
+      problem("string_ contains invalid UTF-8");
+  } else if (node->tag == JSON_ARRAY || node->tag == JSON_OBJECT) {
+    JsonNode *head = node->children.head;
+    JsonNode *tail = node->children.tail;
+
+    if (head == NULL || tail == NULL) {
+      if (head != NULL)
+        problem("tail is NULL, but head is not");
+      if (tail != NULL)
+        problem("head is NULL, but tail is not");
+    } else {
+      JsonNode *child;
+      JsonNode *last = NULL;
+
+      if (head->prev != NULL)
+        problem("First child's prev pointer is not NULL");
+
+      for (child = head; child != NULL; last = child, child = child->next) {
+        if (child == node)
+          problem("node is its own child");
+        if (child->next == child)
+          problem("child->next == child (cycle)");
+        if (child->next == head)
+          problem("child->next == head (cycle)");
+
+        if (child->parent != node)
+          problem("child does not point back to parent");
+        if (child->next != NULL && child->next->prev != child)
+          problem("child->next does not point back to child");
+
+        if (node->tag == JSON_ARRAY && child->key != NULL)
+          problem("Array element's key is not NULL");
+        if (node->tag == JSON_OBJECT && child->key == NULL)
+          problem("Object member's key is NULL");
+
+        if (!json_check(child, errmsg))
+          return false;
+      }
+
+      if (last != tail)
+        problem("tail does not match pointer found by starting at head and following next links");
+    }
+  }
+
+  return true;
+
+  #undef problem
+}

--- a/elab/json.hpp
+++ b/elab/json.hpp
@@ -1,0 +1,117 @@
+/*
+  Copyright (C) 2011 Joseph A. Adams (joeyadams3.14159@gmail.com)
+  All rights reserved.
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in
+  all copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  THE SOFTWARE.
+*/
+
+#ifndef CCAN_JSON_H
+#define CCAN_JSON_H
+
+#include <stdbool.h>
+#include <stddef.h>
+
+typedef enum {
+  JSON_NULL,
+  JSON_BOOL,
+  JSON_STRING,
+  JSON_NUMBER,
+  JSON_ARRAY,
+  JSON_OBJECT,
+} JsonTag;
+
+typedef struct JsonNode JsonNode;
+
+struct JsonNode
+{
+  /* only if parent is an object or array (NULL otherwise) */
+  JsonNode *parent;
+  JsonNode *prev, *next;
+  
+  /* only if parent is an object (NULL otherwise) */
+  char *key; /* Must be valid UTF-8. */
+  
+  JsonTag tag;
+  union {
+    /* JSON_BOOL */
+    bool bool_;
+    
+    /* JSON_STRING */
+    char *string_; /* Must be valid UTF-8. */
+    
+    /* JSON_NUMBER */
+    double number_;
+    
+    /* JSON_ARRAY */
+    /* JSON_OBJECT */
+    struct {
+      JsonNode *head, *tail;
+    } children;
+  };
+};
+
+/*** Encoding, decoding, and validation ***/
+
+JsonNode   *json_decode         (const char *json);
+char       *json_encode         (const JsonNode *node);
+char       *json_encode_string  (const char *str);
+char       *json_stringify      (const JsonNode *node, const char *space);
+void        json_delete         (JsonNode *node);
+
+bool        json_validate       (const char *json);
+
+/*** Lookup and traversal ***/
+
+JsonNode   *json_find_element   (JsonNode *array, int index);
+JsonNode   *json_find_member    (JsonNode *object, const char *key);
+
+JsonNode   *json_first_child    (const JsonNode *node);
+
+#define json_foreach(i, object_or_array)            \
+  for ((i) = json_first_child(object_or_array);   \
+     (i) != NULL;                               \
+     (i) = (i)->next)
+
+/*** Construction and manipulation ***/
+
+JsonNode *json_mknull(void);
+JsonNode *json_mkbool(bool b);
+JsonNode *json_mkstring(const char *s);
+JsonNode *json_mknumber(double n);
+JsonNode *json_mkarray(void);
+JsonNode *json_mkobject(void);
+
+void json_append_element(JsonNode *array, JsonNode *element);
+void json_prepend_element(JsonNode *array, JsonNode *element);
+void json_append_member(JsonNode *object, const char *key, JsonNode *value);
+void json_prepend_member(JsonNode *object, const char *key, JsonNode *value);
+
+void json_remove_from_parent(JsonNode *node);
+
+/*** Debugging ***/
+
+/*
+ * Look for structure and encoding problems in a JsonNode or its descendents.
+ *
+ * If a problem is detected, return false, writing a description of the problem
+ * to errmsg (unless errmsg is NULL).
+ */
+bool json_check(const JsonNode *node, char errmsg[256]);
+
+#endif

--- a/elab/map_col.cpp
+++ b/elab/map_col.cpp
@@ -1,0 +1,80 @@
+// include library
+#include <omp.h>
+#include <algorithm>
+#include <stdexcept>
+
+#include "map_col.hpp"
+
+// add namespace for c++
+namespace SourceMap
+{
+
+	ColMap::ColMap()
+	{
+		this->type = 0;
+		this->col = 0;
+		this->src_idx = 0;
+		this->src_line = 0;
+		this->src_col = 0;
+		this->tkn_idx = 0;
+		this->text  = std::string_view{""};
+	}
+
+	ColMap::~ColMap()
+	{ }
+
+	ColMap::ColMap(size_t col)
+	{
+		this->type = 1;
+		this->col = col;
+		this->src_idx = 0;
+		this->src_line = 0;
+		this->src_col = 0;
+		this->tkn_idx = 0;
+		this->text  = std::string_view{""};
+	}
+
+	ColMap::ColMap(size_t col, size_t idx, size_t src_ln, size_t src_col)
+	{
+		this->type = 4;
+		this->col = col;
+		this->src_idx = idx;
+		this->src_line = src_ln;
+		this->src_col = src_col;
+		this->tkn_idx = 0;
+		this->text  = std::string_view{""};
+	}
+
+	ColMap::ColMap(size_t col, size_t idx, size_t src_ln, size_t src_col, size_t token)
+	{
+		this->type = 5;
+		this->col = col;
+		this->src_idx = idx;
+		this->src_line = src_ln;
+		this->src_col = src_col;
+		this->tkn_idx = token;
+		this->text  = std::string_view{""};
+	}
+
+	size_t ColMap::getType() const { return this->type; }
+
+	bool ColMap::operator== (const ColMap &entry) const { return (col == entry.col); }
+	bool ColMap::operator!= (const ColMap &entry) const { return (col != entry.col); }
+	bool ColMap::operator<  (const ColMap &entry) const { return (col <  entry.col); }
+	bool ColMap::operator<= (const ColMap &entry) const { return (col <= entry.col); }
+
+	// ToDo: check for out of bound access
+	size_t ColMap::getCol() const { return this->col; }
+	size_t ColMap::getSource() const { return this->src_idx; }
+	size_t ColMap::getSrcLine() const { return this->src_line; }
+	size_t ColMap::getSrcCol() const { return this->src_col; }
+	size_t ColMap::getToken() const { return this->tkn_idx; }
+
+}
+// EO namespace
+
+// implement for c
+extern "C"
+{
+
+}

--- a/elab/map_col.hpp
+++ b/elab/map_col.hpp
@@ -1,0 +1,80 @@
+#ifndef SOURCEMAP_ENTRY
+#define SOURCEMAP_ENTRY
+
+#include <set>
+#include <vector>
+#include <string>
+#include <cstring>
+#include <iostream>
+#include <memory>
+
+#include "sourcemap.hpp"
+#include "pos_idx.hpp"
+
+// add namespace for c++
+namespace SourceMap
+{
+
+	class ColMap PANDA_INHERIT
+	{
+		friend class LineMap;
+		friend class Mappings;
+		friend class SrcMapDoc;
+		public: // ctor
+			ColMap();
+			ColMap(size_t col);
+			ColMap(size_t col, size_t src_idx, size_t src_ln, size_t src_col);
+			ColMap(size_t col, size_t src_idx, size_t src_ln, size_t src_col, size_t tkn_idx);
+			virtual ~ColMap();
+		public: // operators
+			bool operator== (const ColMap &entry) const;
+			bool operator!= (const ColMap &entry) const;
+			bool operator<= (const ColMap &entry) const;
+			bool operator< (const ColMap &entry) const;
+			bool operator== (ColMap &entry) const;
+			bool operator!= (ColMap &entry) const;
+			bool operator<= (ColMap &entry) const;
+			bool operator< (ColMap &entry) const;
+		public: // setters
+			void setType(size_t type) { this->type = type; };
+			void setCol(size_t col) { this->col = col; };
+			void setSource(size_t src_idx) { this->src_idx = src_idx; };
+			void setSrcLine(size_t src_ln) { this->src_line = src_ln; };
+			void setSrcCol(size_t src_col) { this->src_col = src_col; };
+			void setToken(size_t tkn_idx) { this->tkn_idx = tkn_idx; };
+		public: // getters
+			size_t getType() const;
+			size_t getCol() const;
+			size_t getSource() const;
+			size_t getSrcLine() const;
+			size_t getSrcCol() const;
+			size_t getToken() const;
+		public: // variables
+			size_t type;
+			size_t col;
+			size_t src_idx;
+			size_t src_line;
+			size_t src_col;
+			size_t tkn_idx;
+			std::string_view text;
+			// SrcMapWP doc;
+	};
+
+	// typedef weak_ptr<ColMap> EntryWP;
+	typedef shared_ptr<ColMap> ColMapSP;
+
+	struct ColMapComp {
+		bool operator() (const ColMapSP& lhs, const ColMapSP& rhs) const
+		{
+			return lhs.get() && rhs.get() &&
+			       lhs->col < rhs->col;
+		}
+	};
+
+	typedef std::vector<ColMapSP> ColMapArr;
+	typedef std::set<ColMapSP, ColMapComp> ColMapSet;
+
+}
+// EO namespace
+
+#endif

--- a/elab/map_line.cpp
+++ b/elab/map_line.cpp
@@ -1,0 +1,58 @@
+// include library
+#include <omp.h>
+#include <set>
+#include <stdexcept>
+#include <algorithm>
+
+#include "document.hpp"
+
+// using string
+using namespace std;
+
+// add namespace for c++
+namespace SourceMap
+{
+
+	LineMap::LineMap()
+	: entries()
+	{ }
+
+	LineMap::~LineMap()
+	{ }
+
+	size_t LineMap::getLength() const {
+		return entries.size();
+	}
+
+	const ColMapSP LineMap::getColMap(size_t idx) const {
+		if (idx >= 0 && idx < entries.size()) {
+			return entries[idx];
+		}
+		throw(invalid_argument("getColMap out of bound"));
+	}
+
+	void LineMap::addEntry(ColMapSP entry)
+	{
+		entries.push_back(entry);
+	}
+
+	const vector<ColMapSP> LineMap::at(size_t col) const
+	{
+		vector<ColMapSP> entries;
+		auto entry_it = this->entries.begin();
+		auto entry_end = this->entries.end();
+		// search from left up to position
+		for(; entry_it != entry_end; ++entry_it) {
+			ColMapSP entry = *entry_it;
+			// collect entries on position
+			if (entry->col == col)
+			{ entries.push_back(entry); }
+			// abort the loop after position
+			else if (entry->col > col) break;
+		}
+		return entries;
+	}
+
+
+}
+// EO namespace

--- a/elab/map_line.hpp
+++ b/elab/map_line.hpp
@@ -1,0 +1,41 @@
+#ifndef SOURCEMAP_ROW
+#define SOURCEMAP_ROW
+
+#include <vector>
+#include <string>
+#include <cstring>
+#include <iostream>
+
+#include "map_col.hpp"
+#include "sourcemap.hpp"
+
+// add namespace for c++
+namespace SourceMap
+{
+
+	class LineMap PANDA_INHERIT
+	{
+		friend class ColMap;
+		friend class Mappings;
+		friend class SrcMapDoc;
+		public: // ctor
+			LineMap();
+			virtual ~LineMap();
+		public: // setters
+			void addEntry(ColMapSP entry);
+		public: // getters
+			size_t getLength() const;
+			size_t getEntryCount() const { return getLength(); };
+			const ColMapSP getColMap(size_t idx) const;
+			const vector<ColMapSP> at(size_t col) const;
+		public: // variables
+			vector<ColMapSP> entries;
+	};
+
+	// typedef weak_ptr<LineMap> RowWP;
+	typedef shared_ptr<LineMap> LineMapSP;
+
+}
+// EO namespace
+
+#endif

--- a/elab/mappings.cpp
+++ b/elab/mappings.cpp
@@ -1,0 +1,68 @@
+// include library
+#include <omp.h>
+#include <algorithm>
+#include <stdexcept>
+
+#include "mappings.hpp"
+#include "v3.hpp"
+
+// add namespace for c++
+namespace SourceMap
+{
+
+	Mappings::Mappings(size_t version)
+	{
+		this->version = version;
+		this->addNewLine(0);
+		this->last_ln_col = 0;
+	}
+
+	Mappings::Mappings(string VLQ, size_t version)
+	{
+		this->version = version;
+		this->addNewLine(0);
+		this->last_ln_col = 0;
+		this->init(VLQ);
+	}
+
+	Mappings::~Mappings()
+	{ }
+
+	const LineMapSP Mappings::getLineMap(size_t idx) const {
+		if (idx >= 0 && idx < rows.size()) return rows[idx];
+		else throw(invalid_argument("out of bound"));
+	}
+
+	const string Mappings::serialize() const
+	{
+		if (this->version == 3) {
+			return SourceMap::Format::V3::serialize(*this);
+		} else {
+			throw(runtime_error("unknown format"));
+		}
+	}
+
+	void Mappings::init(const string& str)
+	{
+		if (this->version == 3) {
+			SourceMap::Format::V3::unserialize(*this, str);
+		} else {
+			throw(runtime_error("unknown format"));
+		}
+	}
+
+	void Mappings::addNewLine(const size_t len)
+	{
+		rows.push_back(make_shared<LineMap>());
+		this->last_ln_col = 0;
+	}
+
+
+}
+// EO namespace
+
+// implement for c
+extern "C"
+{
+
+}

--- a/elab/mappings.hpp
+++ b/elab/mappings.hpp
@@ -1,0 +1,65 @@
+#ifndef SOURCEMAP_MAPPING
+#define SOURCEMAP_MAPPING
+
+#include <vector>
+#include <string>
+#include <cstring>
+#include <iostream>
+
+#include "map_line.hpp"
+#include "sourcemap.hpp"
+#include "pos_txt.hpp"
+
+// add namespace for c++
+namespace SourceMap
+{
+
+	class Mappings PANDA_INHERIT
+	{
+		friend class ColMap;
+		friend class LineMap;
+		friend class SrcMapDoc;
+		public: // ctor
+			Mappings(size_t version = 3);
+			// we only implement v3 currently
+			Mappings(string VLQ, size_t version = 3);
+			virtual ~Mappings();
+		public: // operators
+			friend ostream& operator<<(ostream& os, const Mappings& map);
+		public: // setters
+			void addNewLine(size_t len = 0);
+			// void addNewLine(const char* line);
+		public: // getters
+			const LineMapSP getLineMap(size_t idx) const;
+			size_t getRowCount() const { return rows.size(); };
+			size_t getLastRowSize() const { return last_ln_col; };
+			void setLastRowSize(size_t col) { last_ln_col = col; };
+			SrcMapPos getSize() const {
+				return SrcMapPos(
+					getRowCount(),
+					getLastRowSize()
+				);
+			};
+		public: // getters
+			const string serialize() const;
+		public: // route to row
+			vector<ColMapSP> at(size_t row, size_t col) const
+			{ return getLineMap(row)->at(col); };
+			vector<ColMapSP> at(const SrcMapPos& pos) const
+			{ return getLineMap(pos.row)->at(pos.col); };
+		public: // variables
+			// SrcMapPos size;
+			vector<LineMapSP> rows;
+		private: // variables
+			size_t version;
+			size_t last_ln_col;
+			void init(const string& VLQ);
+	};
+
+	// typedef weak_ptr<Mappings> MappingWP;
+	typedef shared_ptr<Mappings> MappingsSP;
+
+}
+// EO namespace
+
+#endif

--- a/elab/pos_idx.cpp
+++ b/elab/pos_idx.cpp
@@ -1,0 +1,43 @@
+// include library
+#include <algorithm>
+#include <stdexcept>
+
+#include "pos_idx.hpp"
+
+// add namespace for c++
+namespace SourceMap
+{
+
+	SrcMapIdx::SrcMapIdx()
+	{
+		this->row = -1;
+		this->idx = -1;
+	}
+
+	SrcMapIdx::SrcMapIdx(size_t row, size_t idx)
+	{
+		this->row = row;
+		this->idx = idx;
+	}
+
+	const SrcMapIdx SrcMapIdx::operator+ (const SrcMapIdx &pos)
+	{
+		return SrcMapIdx(row + pos.row, pos.row > 0 ? pos.idx : pos.idx + idx);
+	}
+	bool SrcMapIdx::operator== (const SrcMapIdx &pos) const
+	{
+		return row == pos.row && idx == pos.idx;
+	}
+	bool SrcMapIdx::operator!= (const SrcMapIdx &pos) const
+	{
+		return row != pos.row || idx != pos.idx;
+	}
+
+}
+// EO namespace
+
+// implement for c
+extern "C"
+{
+
+}

--- a/elab/pos_idx.hpp
+++ b/elab/pos_idx.hpp
@@ -1,0 +1,52 @@
+#ifndef SOURCEMAP_INDEX
+#define SOURCEMAP_INDEX
+
+#include <vector>
+#include <string>
+#include <cstring>
+#include <iostream>
+
+#include "sourcemap.hpp"
+
+// add namespace for c++
+namespace SourceMap
+{
+
+	class SrcMapIdx
+	{
+		friend class LineMap;
+		friend class Mappings;
+		friend class SrcMapDoc;
+		public: // ctor
+			SrcMapIdx();
+			SrcMapIdx(size_t row, size_t idx);
+		public: // operators
+			// just compares idx and row value
+			bool operator== (const SrcMapIdx& pos) const;
+			bool operator!= (const SrcMapIdx& pos) const;
+			// this plus operation is not commutative
+			// so the order of the summands is important
+			const SrcMapIdx operator+ (const SrcMapIdx& pos);
+			// minus is not possible, since we do not know the
+			// length of each line, so we cannot calculate idx
+			friend ostream& operator<<(ostream& os, const SrcMapIdx& pos);
+		public: // setters
+			void getLineMap(size_t row) { this->row = row; };
+			void getCol(size_t idx) { this->idx = idx; };
+		public: // getters
+			size_t getLineMap() const { return row; };
+			size_t getCol() const { return idx; };
+		public: // variables
+			size_t row;
+			size_t idx;
+
+	};
+
+	// are these really that usefull?
+	const SrcMapIdx SrcMapIdxNull(0, 0);
+	const SrcMapIdx SrcMapIdxError(-1, -1);
+
+}
+// EO namespace
+
+#endif

--- a/elab/pos_txt.cpp
+++ b/elab/pos_txt.cpp
@@ -1,0 +1,58 @@
+// include library
+#include <algorithm>
+#include <stdexcept>
+
+#include "pos_txt.hpp"
+
+// add namespace for c++
+namespace SourceMap
+{
+
+	SrcMapPos::SrcMapPos()
+	{
+		this->row = -1;
+		this->col = -1;
+	}
+
+	SrcMapPos::SrcMapPos(size_t row, size_t col)
+	{
+		this->row = row;
+		this->col = col;
+	}
+
+	SrcMapPos::SrcMapPos(const string& data)
+	{
+		this->row = 0;
+		this->col = 0;
+		size_t prev = 0;
+		size_t last = data.size();
+		for(size_t i = 0; i < last; ++i) {
+			if (data[i] == '\n') {
+				++ this->row;
+				prev = i + 1;
+			}
+		}
+		this->col = last - prev;
+	}
+
+	const SrcMapPos SrcMapPos::operator+ (const SrcMapPos &pos)
+	{
+		return SrcMapPos(row + pos.row, pos.row > 0 ? pos.col : pos.col + col);
+	}
+	bool SrcMapPos::operator== (const SrcMapPos &pos) const
+	{
+		return row == pos.row && col == pos.col;
+	}
+	bool SrcMapPos::operator!= (const SrcMapPos &pos) const
+	{
+		return row != pos.row || col != pos.col;
+	}
+
+}
+// EO namespace
+
+// implement for c
+extern "C"
+{
+
+}

--- a/elab/pos_txt.hpp
+++ b/elab/pos_txt.hpp
@@ -1,0 +1,54 @@
+#ifndef SOURCEMAP_POSITION
+#define SOURCEMAP_POSITION
+
+#include <vector>
+#include <string>
+#include <cstring>
+#include <iostream>
+
+#include "sourcemap.hpp"
+
+// add namespace for c++
+namespace SourceMap
+{
+
+	class SrcMapPos
+	{
+		friend class LineMap;
+		friend class Mappings;
+		friend class SrcMapDoc;
+		public: // ctor
+			SrcMapPos();
+			SrcMapPos(const string& data);
+			SrcMapPos(size_t row, size_t col);
+		public: // operators
+			// just compares col and row value
+			bool operator== (const SrcMapPos& pos) const;
+			bool operator!= (const SrcMapPos& pos) const;
+			// this plus operation is not commutative
+			// so the order of the summands is important
+			const SrcMapPos operator+ (const SrcMapPos& pos);
+			// minus is not possible, since we do not know the
+			// length of each line, so we cannot calculate col
+			friend ostream& operator<<(ostream& os, const SrcMapPos& pos);
+		public: // setters
+			void getLineMap(size_t row) { this->row = row; };
+			void getCol(size_t col) { this->col = col; };
+		public: // getters
+			size_t getLineMap() const { return row; };
+			size_t getCol() const { return col; };
+		public: // variables
+			size_t row;
+			size_t col;
+
+	};
+
+	// are these really that usefull?
+	const SrcMapPos SrcMapPosNull(0, 0);
+	const SrcMapPos SrcMapPosStart(0, 0);
+	const SrcMapPos SrcMapPosError(-1, -1);
+
+}
+// EO namespace
+
+#endif

--- a/elab/sourcemap.hpp
+++ b/elab/sourcemap.hpp
@@ -1,0 +1,124 @@
+#ifndef SOURCEMAP_TYPEDEF
+#define SOURCEMAP_TYPEDEF
+#define USE_STD_SHARED_PTR
+
+#include <cstddef> // __GLIBCXX__, _HAS_TR1
+
+// GNU C++ or Intel C++ using libstd++.
+//
+#if defined (__GNUC__) && __GNUC__ >= 4 && \
+  defined (__GLIBCXX__)
+#  include <tr1/memory>
+//
+// IBM XL C++.
+//
+#elif defined (__xlC__) && __xlC__ >= 0x0900
+#  define __IBMCPP_TR1__
+#  include <memory>
+//
+// VC++ or Intel C++ using VC++ standard library.
+//
+#elif defined (_MSC_VER) && (_MSC_VER == 1500 && \
+  defined (_HAS_TR1) || _MSC_VER > 1500)
+#  include <memory>
+//
+// Boost fall-back.
+//
+#else
+#  include <boost/tr1/memory.hpp>
+#endif
+
+#include <iostream>
+#include <exception>
+#include <stdexcept>
+#include <vector>
+
+#ifdef __cplusplus
+
+// #define HAS_PANDA
+// #define PANDA_REFCNT
+
+#ifdef HAS_PANDA
+
+	#include <panda/def.h>
+	#include <panda/cast.h>
+	#include <panda/refcnt.h>
+	#include <panda/traits.h>
+
+	#ifdef PANDA_REFCNT
+		#define PANDA_INHERIT : virtual public panda::RefCounted
+	#endif
+
+#endif
+
+#ifndef PANDA_INHERIT
+	#define PANDA_INHERIT
+#endif
+
+// add namespace for c++
+namespace SourceMap
+{
+
+	// import some stuff
+	using std::cerr;
+	using std::endl;
+	using std::vector;
+	using std::string;
+	using std::ostream;
+	using std::stringstream;
+	using std::istringstream;
+	using std::logic_error;
+	using std::out_of_range;
+	using std::runtime_error;
+	using std::invalid_argument;
+
+	#if defined(USE_STD_SHARED_PTR)
+		using std::shared_ptr;
+		using std::make_shared;
+	#elif defined(USE_STD_TR1_SHARED_PTR)
+		using std::tr1::shared_ptr;
+		template< class T, class... Args >
+		shared_ptr<T> make_shared( Args&&... args )
+		{ return shared_ptr<T>(new T(args...)); }
+	#elif defined(USE_BOOST_SHARED_PTR)
+		using boost::shared_ptr;
+		using boost::make_shared;
+	#else
+		#error No shared-pointer implementation selected!
+	#endif
+
+	#define foreach(type, variable, array) \
+		auto variable = array.begin(); \
+		auto end_##variable = array.end(); \
+		for(; variable != end_##variable; ++variable)
+
+	#define foreach_ptr(type, variable, array) \
+		auto it_##variable = array.begin(); \
+		auto end_##variable = array.end(); \
+		for(shared_ptr<type> variable; it_##variable != end_##variable && (variable = *it_##variable); ++it_##variable)
+
+	#define const_foreach(type, variable, const_array) \
+		auto variable = const_array.begin(); \
+		auto end_##variable = const_array.end(); \
+		for(; variable != end_##variable; ++variable)
+
+	#define const_foreach_ptr(type, variable, array) \
+		auto it_##variable = array.begin(); \
+		auto end_##variable = array.end(); \
+		for(shared_ptr<type> variable; it_##variable != end_##variable && (variable = *it_##variable); ++it_##variable)
+
+};
+// EO namespace
+
+
+// declare for c
+extern "C" {
+#endif
+
+// void foobar();
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/elab/v3.cpp
+++ b/elab/v3.cpp
@@ -1,0 +1,255 @@
+// include library
+#include <stdexcept>
+
+#include "v3.hpp"
+
+// add namespace for c++
+namespace SourceMap
+{
+	namespace Format
+	{
+		namespace V3
+		{
+
+			// A Base64 VLQ digit can represent 5 bits, so it is base-32.
+			const int VLQ_BASE_SHIFT = 5;
+			const int VLQ_BASE = 1 << VLQ_BASE_SHIFT;
+
+			// A mask of bits for a VLQ digit (11111), 31 decimal.
+			const int VLQ_BASE_MASK = VLQ_BASE-1;
+
+			// The continuation bit is the 6th bit.
+			const int VLQ_CONTINUATION_BIT = VLQ_BASE;
+
+			/**
+			 * Converts from a two-complement value to a value where the sign bit is
+			 * is placed in the least significant bit. For example, as decimals:
+			 *   1 becomes 2 (10 binary), -1 becomes 3 (11 binary)
+			 *   2 becomes 4 (100 binary), -2 becomes 5 (101 binary)
+			 */
+			int toVLQSigned(int value) {
+				if (value < 0) {
+					return ((-value) << 1) + 1;
+				} else {
+					return (value << 1) + 0;
+				}
+			}
+
+			/**
+			 * Converts to a two-complement value from a value where the sign bit is
+			 * is placed in the least significant bit. For example, as decimals:
+			 *   2 (10 binary) becomes 1, 3 (11 binary) becomes -1
+			 *   4 (100 binary) becomes 2, 5 (101 binary) becomes -2
+			 */
+			int fromVLQSigned(int value) {
+				int negate = (value & 1) == 1;
+				value = value >> 1;
+				return negate ? -value : value;
+			}
+
+			/**
+			  * Coverts a interger value to base64 char
+			*/
+			char toBase64(int i) {
+				if (i >= 0 && i < 26) { return char(i + 65); }
+				else if (i > 25 && i < 52) { return char(i + 71); }
+				else if (i > 51 && i < 62) { return char(i - 4); }
+				else if (i == 62) { return char(43); }
+				else if (i == 63) { return char(47); }
+				throw(invalid_argument("base 64 integer out of bound"));
+			}
+
+			/**
+			  * Coverts a char from base64 to integer value.
+			*/
+			int fromBase64(char c) {
+				if (c > 95 && c < 123) { return c - 71; }
+				else if (c > 64 && c < 91) { return c - 65; }
+				else if (c > 47 && c < 59) { return c + 4; }
+				else if (c == 43) { return 62; }
+				else if (c == 47) { return 63; }
+				throw(invalid_argument("base 64 char out of bound"));
+			}
+
+			/**
+			 * Writes a VLQ encoded value to the provide appendable.
+			 * @throws IOException
+			 */
+			string encodeVLQ(int value) {
+				string result = "";
+				value = toVLQSigned(value);
+				do {
+					int digit = value & VLQ_BASE_MASK;
+					value = (unsigned int)value >> VLQ_BASE_SHIFT;
+					if (value > 0) {
+						digit |= VLQ_CONTINUATION_BIT;
+					}
+					result += toBase64(digit);
+				} while (value > 0);
+				return result;
+			}
+
+			/**
+			 * Decodes the next VLQValue from the provided iterator.
+			 */
+			int decodeVLQ(string::const_iterator& it, string::const_iterator& end) {
+				int result = 0;
+				int continuation;
+				int shift = 0;
+				do {
+					char c = *it;
+					int digit = fromBase64(c);
+					continuation = (digit & VLQ_CONTINUATION_BIT) != 0;
+					digit &= VLQ_BASE_MASK;
+					result = result + (digit << shift);
+					shift = shift + VLQ_BASE_SHIFT;
+					if (continuation) ++it;
+				} while (continuation && it != end);
+				return fromVLQSigned(result);
+			}
+
+			const string serialize(const Mappings& map)
+			{
+
+				string result = "";
+
+				size_t column = 0;
+				size_t source = 0;
+				size_t in_line = 0;
+				size_t in_col = 0;
+				size_t token = 0;
+
+				for(size_t i = 0; i < map.getRowCount(); ++i) {
+					LineMap* row = map.rows[i].get();
+					for(size_t n = 0; n < row->getEntryCount(); ++n) {
+						const ColMap* entry = row->getColMap(n).get();
+						if (entry->getType() == 1) {
+							result += encodeVLQ(entry->getCol() - column);
+							source = entry->getCol();
+						} else if (entry->getType() == 4) {
+							result += encodeVLQ(entry->getCol() - column);
+							result += encodeVLQ(entry->getSource() - source);
+							result += encodeVLQ(entry->getSrcLine() - in_line);
+							result += encodeVLQ(entry->getSrcCol() - in_col);
+							column = entry->getCol();
+							source = entry->getSource();
+							in_line = entry->getSrcLine();
+							in_col = entry->getSrcCol();
+						} else if (entry->getType() == 5) {
+							result += encodeVLQ(entry->getCol() - column);
+							result += encodeVLQ(entry->getSource() - source);
+							result += encodeVLQ(entry->getSrcLine() - in_line);
+							result += encodeVLQ(entry->getSrcCol() - in_col);
+							result += encodeVLQ(entry->getToken() - token);
+							column = entry->getCol();
+							source = entry->getSource();
+							in_line = entry->getSrcLine();
+							in_col = entry->getSrcCol();
+							token = entry->getToken();
+						}
+						if (n + 1 != row->getEntryCount()) result += ",";
+					}
+					if (i + 1 != map.getRowCount()) result += ";";
+
+				column = 0; }
+
+				return result;
+
+			}
+
+			void unserialize(Mappings& map, const string& data)
+			{
+
+				string::const_iterator it = data.begin();
+				string::const_iterator end = data.end();
+
+				LineMapSP row = map.rows.back();
+
+				size_t column = 0;
+				size_t source = 0;
+				size_t in_line = 0;
+				size_t in_col = 0;
+				size_t token = 0;
+
+				vector<int> offset;
+				while(true) {
+
+					// check if we reached a delimiter for entries
+					if (it == end || *it == ',' || *it == ';') {
+
+						// only create valid entries
+						// checks out of bound access
+						if (
+							offset.size() == 1 &&
+							int(offset[0] + column) >= 0
+						) {
+							row->addEntry(SourceMap::make_shared<ColMap>(
+								column += offset[0]
+							));
+						}
+						else if (
+							offset.size() == 4 &&
+							int(offset[0] + column) >= 0 &&
+							int(offset[1] + source) >= 0 &&
+							int(offset[2] + in_line) >= 0 &&
+							int(offset[3] + in_col) >= 0
+						) {
+							row->addEntry(SourceMap::make_shared<ColMap>(
+								column += offset[0],
+								source += offset[1],
+								in_line += offset[2],
+								in_col += offset[3]
+							));
+						}
+						else if (
+							offset.size() == 5 &&
+							int(offset[0] + column) >= 0 &&
+							int(offset[1] + source) >= 0 &&
+							int(offset[2] + in_line) >= 0 &&
+							int(offset[3] + in_col) >= 0 &&
+							int(offset[4] + token) >= 0
+						) {
+							row->addEntry(SourceMap::make_shared<ColMap>(
+								column += offset[0],
+								source += offset[1],
+								in_line += offset[2],
+								in_col += offset[3],
+								token += offset[4]
+							));
+						}
+						// empty rows are allowed
+						else if (offset.size() != 0) {
+							// everything else is not valid
+							throw(runtime_error("invalid source map entry"));
+						}
+
+						// create a new row
+						if (*it == ';') {
+							map.addNewLine();
+							row = map.rows.back();
+						column = 0; }
+
+						// clear for next
+						offset.clear();
+
+						// exit loop if at end
+						if (it == end) break;
+
+					} else {
+
+						// parse a vlq number and put to offset
+						offset.push_back(decodeVLQ(it, end));
+
+					}
+
+					// advance
+					++it;
+
+				}
+
+			}
+
+		}
+	}
+}
+// EO namespace

--- a/elab/v3.hpp
+++ b/elab/v3.hpp
@@ -1,0 +1,28 @@
+#ifndef SOURCEMAP_FORMAT_V3
+#define SOURCEMAP_FORMAT_V3
+
+#include <vector>
+#include <string>
+#include <cstring>
+#include <iostream>
+#include <algorithm>
+
+#include "sourcemap.hpp"
+#include "mappings.hpp"
+
+// add namespace for c++
+namespace SourceMap
+{
+	namespace Format
+	{
+		namespace V3
+		{
+			const string serialize(const Mappings& map);
+			void unserialize(Mappings& map, const string& data);
+		}
+	}
+
+}
+// EO namespace
+
+#endif


### PR DESCRIPTION
Sourcemaps are implemented as an alternative to the Token class in elab_scanner.* Modify the use_Token bool in elab_scanner.hpp to switch between Tokens and Sourcemaps.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/masc-ucsc/livehd/190)
<!-- Reviewable:end -->
