### PR TITLE
Mark "pyrope_compile" as flaky

### DIFF
--- a/pass/compiler/BUILD
+++ b/pass/compiler/BUILD
@@ -30,10 +30,11 @@ sh_test(
         "//inou/pyrope:pyrope_tests",
         "//main:lgshell",
     ],
-    # tags = [
-    #     "fixme",
-    #     "manual",
-    # ],
+    tags = [
+        "fixme",
+        "flaky",
+        # "manual",
+    ],
     deps = [
         "//inou/yosys:scripts",
     ],


### PR DESCRIPTION
Recent CI logs show that it both passes and fails with the same code \[1]\[2]:

1: https://github.com/masc-ucsc/livehd/runs/2242940919
2: https://github.com/masc-ucsc/livehd/runs/2243310440

Error:

```
----------------------------------------------------
LGraph -> Verilog
----------------------------------------------------
livehd cmd lgraph.open name:reg_bits_set |> inou.yosys.fromlg hier:true
path:bazel-out/k8-fastbuild/bin/main
inline:0:56 error: yosys setup could not find the provided script: file
lgraph.open name:reg_bits_set |> inou.yosys.fromlg hier:true
Pass::Error: yosys setup could not find the provided script: file
elab/elab_scanner.cpp:447 :assertion false failed
Compiler pass error! debug with gdb
bazel-out/k8-fastbuild/bin/pass/compiler/pyrope_compile.runfiles/livehd/pass/compiler/pyrope_compile: line 76:
102 Aborted                 (core dumped) ${LGSHELL} "lgraph.open name:${pt} |> inou.yosys.fromlg hier:true"

ERROR: Pyrope compiler failed: verilog generation, testcase: ./inou/pyrope/tests/compiler/reg_bits_set.prp
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/masc-ucsc/livehd/204)
<!-- Reviewable:end -->
