### PR TITLE
Fixes tests, deal with Clang warnings

### DIFF
--- a/core/graph_core.hpp
+++ b/core/graph_core.hpp
@@ -73,7 +73,7 @@ protected:
     bool try_add_sink(Index_id id);                  // return false if there was no space
     uint8_t insert_edge(Index_id insert_id);
     uint8_t delete_edge();
-    uint8_t edge_storage[64 - 1];
+    uint8_t edge_storage[64];
     uint8_t last_byte;
     uint8_t overflow_next : 6;
     uint8_t creator_pointer;

--- a/core/sub_node.hpp
+++ b/core/sub_node.hpp
@@ -96,8 +96,9 @@ public:
     name.clear();
     expunge();
   }
-  // Sub_node(const Sub_node &s) = delete;
+  Sub_node(const Sub_node &s) = default;
   Sub_node &operator=(const Sub_node &) = delete;
+
   void      copy_from(std::string_view new_name, Lg_type_id new_lgid, const Sub_node &sub);
 
   void to_json(rapidjson::PrettyWriter<rapidjson::StringBuffer> &writer) const;

--- a/inou/liveparse/chunkify_verilog_test.cpp
+++ b/inou/liveparse/chunkify_verilog_test.cpp
@@ -73,7 +73,7 @@ TEST_F(VTest1, interface) {
 void test_throw() {
   std::string test2_verilog = "";
 
-  mkdir("tdelta/noaccess_dir", 0000);
+  mkdir("lgdb/noaccess_dir", 0000);
 
   Chunkify_verilog chunker("lgdb/noaccess_dir");
   chunker.parse_inline(test2_verilog.c_str());

--- a/pass/lnastopt/BUILD
+++ b/pass/lnastopt/BUILD
@@ -1,6 +1,6 @@
 # This file is distributed under the BSD 3-Clause License. See LICENSE for details.
 
-load("@rules_cc//cc:defs.bzl", "cc_library", "cc_test") # @unused
+load("@rules_cc//cc:defs.bzl", "cc_library")
 load("//tools:copt_default.bzl", "COPTS")
 
 cc_library(


### PR DESCRIPTION
```
    sub_node: explicitly define copy constructor

    Fixes:

    core/sub_node.hpp:100:13: error: definition of implicit copy
    constructor for 'Sub_node' is deprecated because it has a use
    -declared copy assignment operator [-Werror,-Wdeprecated-copy]

      Sub_node &operator=(const Sub_node &) = delete;
```

```
    graph_core: increase array size to fix illegal memory access

    Fixes:

    core/graph_core.cpp:217:7: error: array index 63 is past the end of the array
     (which contains 63 elements) [-Werror,-Warray-bounds]
       if(edge_storage[63] != 0){
```

```
    chunkify_verilog_test: fix wrong noaccess_dir test dir path
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/masc-ucsc/livehd/211)
<!-- Reviewable:end -->
