### PR TITLE
graph_core: fixup dd8a54285, remove redundant "last_byte"

### DIFF
--- a/core/graph_core.cpp
+++ b/core/graph_core.cpp
@@ -213,12 +213,14 @@ uint8_t Graph_core::Entry16::delete_edge(uint8_t rel_index){
  */
 
 uint8_t Graph_core::Entry64::insert_edge(Index_id insert_id){
-
-   if(edge_storage[63] != 0){ //overflow is full
-
-     for (int i = 0; i < 64; ++i){       // loop through to see if any edge > insert edge
-       if(insert_id < edge_storage[i]){  // if a greater edge is found
-         auto temp = edge_storage[63];   // get the last element
+   // overflow is full
+   if(last_byte() != 0){
+     // loop through to see if any edge > insert edge
+     for (unsigned long i = 0; i < sizeof(edge_storage); ++i){
+       // if a greater edge is found
+       if(insert_id < edge_storage[i]) {
+         // get the last element
+         auto temp = last_byte();
          delete_edge();                  // remove that edge from the edge
          insert_edge(insert_id);         // now that edge storage is not empty we can insert
          return temp;                    // return temp to add_edge to make a new overflow
@@ -256,7 +258,7 @@ uint8_t Graph_core::Entry64::insert_edge(Index_id insert_id){
 
 ///*
 uint8_t Graph_core::Entry64::delete_edge(){
-   for(int i = 63; i >= 0; --i){
+   for(int i = sizeof(edge_storage) - 1; i >= 0; --i){
      if(edge_storage[i] != 0){
        edge_storage[i] = 0;
        return 0; // success
@@ -358,7 +360,7 @@ void Graph_core::add_edge(const Index_id sink_id, const Index_id driver_id){
 uint8_t Graph_core::check_overflow_index(Index_id overflow_index, uint8_t type){
    uint8_t correct_overflow = overflow_index;
 
-   while(table[correct_overflow].last_byte != type){ //check whether the type of the overflow is wrong
+   while(table[correct_overflow].last_byte() != type){ //check whether the type of the overflow is wrong
      //if wrong
      if(table[correct_overflow].overflow_next == 0x7){ // check if the next pointer is null
        return 0; // no other overflow and wrong type

--- a/core/graph_core.hpp
+++ b/core/graph_core.hpp
@@ -55,15 +55,13 @@ public:
 class Graph_core {
 protected:
   class __attribute__((packed)) Entry64 {  // AKA Overflow Entry
-  protected:
-    //uint8_t edge_storage[64 - 1];
-    //uint8_t last_byte;
 
   public:
-    constexpr Entry64() : edge_storage{0,},last_byte(0), overflow_next(0), creator_pointer(0) {
+    constexpr Entry64() : edge_storage{0,}, overflow_next(0), creator_pointer(0) {
+      last_byte() = 0;
     }
-    void set_input() { last_byte |= 0x80; }   // set 8th bit
-    void set_output() { last_byte &= 0x7F; }  // clear 8th bit
+    void set_input() { last_byte() |= 0x80; }   // set 8th bit
+    void set_output() { last_byte() &= 0x7F; }  // clear 8th bit
 
     constexpr Index_id get_overflow() const;  // returns the next Entry64 if overflow, zero otherwise
 
@@ -73,8 +71,16 @@ protected:
     bool try_add_sink(Index_id id);                  // return false if there was no space
     uint8_t insert_edge(Index_id insert_id);
     uint8_t delete_edge();
+
+    constexpr uint8_t& last_byte() {
+      return edge_storage[sizeof(edge_storage) - 1];
+    }
+
+    constexpr uint8_t last_byte() const {
+      return edge_storage[sizeof(edge_storage) - 1];
+    }
+
     uint8_t edge_storage[64];
-    uint8_t last_byte;
     uint8_t overflow_next : 6;
     uint8_t creator_pointer;
   };


### PR DESCRIPTION
I am not sure about this, but I believe this is the correct fix. 

Originally, we have two fields in Graph_core:

```
uint8_t edge_storage[64 - 1];
uint8_t last_byte;
```

and the offending code uses:

```
edge_storage[63]
```

This leads to a compiler warning as the access is out of bounds. Practically, `last_byte` will be accessed. Judging from the comments (`get the last element`), I believe @clrighthand0 actually wants to use `last_byte` here. 

dd8a54285 tried to fix the compiler warning by increasing the array size to 64 (as that's the most straightforward solution and 64 seems more logical):

```
uint8_t edge_storage[64]
```

which changes the actual behavior of the related codes. 

This change resolves the issue by replacing the redundant `last_byte` field with last element of `edge_storage`, and additionally always use `[sizeof(edge_storage) - 1]` to access the last element.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/masc-ucsc/livehd/212)
<!-- Reviewable:end -->
