### PR TITLE
edge_test: replace deprecated "std::random_shuffle"

### DIFF
--- a/core/edge.hpp
+++ b/core/edge.hpp
@@ -25,11 +25,12 @@ public:
     Compact() : driver_idx(0), pad1(0), sink_idx(0), pad2(0) {}
 
     Compact &operator=(const Compact &obj) {
-      I(this != &obj);
-      driver_hidx = obj.driver_hidx;
-      driver_idx  = obj.driver_idx;
-      sink_hidx   = obj.sink_hidx;
-      sink_idx    = obj.sink_idx;
+      if (this != &obj) {
+        driver_hidx = obj.driver_hidx;
+        driver_idx  = obj.driver_idx;
+        sink_hidx   = obj.sink_hidx;
+        sink_idx    = obj.sink_idx;
+      };
 
       return *this;
     }

--- a/core/tests/edge_test.cpp
+++ b/core/tests/edge_test.cpp
@@ -1,5 +1,7 @@
 //  This file is distributed under the BSD 3-Clause License. See LICENSE for details.
 
+#include <random>
+
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 #include "lbench.hpp"
@@ -301,7 +303,7 @@ TEST_F(Edge_test, overflow_delete) {
     all_edges.push_back(b.first);
   }
 
-  std::random_shuffle(all_edges.begin(), all_edges.end());
+  std::shuffle(all_edges.begin(), all_edges.end(), std::knuth_b());
 
   for (auto &e : all_edges) {
     XEdge edge(g, e);
@@ -370,7 +372,7 @@ TEST_F(Edge_test, overflow_delete_del_edge_bench) {
     all_edges.push_back(b.first);
   }
 
-  std::random_shuffle(all_edges.begin(), all_edges.end());
+  std::shuffle(all_edges.begin(), all_edges.end(), std::knuth_b());
 
   {
     Lbench bench("core.EDGE_overflow_delete_del_edge");


### PR DESCRIPTION
std::random_shuffle has been removed from C++ 17 standard \[1].

GCC and its libstdc++ are pretty forgiving, but LLVM and its libc++
strictly adhere to the standard.

Note that the assert on self assignment of XEdge is removed, as
std::shuffle may do that \[2]. C++ LWG is aware of this not-well
-defined behavior and recently approved a resolution \[3], but that
would not take effect before C++ 23.

Fixes:

```
core/tests/edge_test.cpp:304:8: error: no member named 'random_shuffle' in namespace 'std'
  std::random_shuffle(all_edges.begin(), all_edges.end());
  ~~~~~^
core/tests/edge_test.cpp:373:8: error: no member named 'random_shuffle' in namespace 'std'
  std::random_shuffle(all_edges.begin(), all_edges.end());
  ~~~~~^
2 errors generated.
```

\[1]: http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2014/n4190
\[2]: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=85828
\[3]: https://cplusplus.github.io/LWG/issue2839

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/masc-ucsc/livehd/214)
<!-- Reviewable:end -->
