### PR TITLE
CI: always store and upload cache at the end

### DIFF
--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -15,7 +15,8 @@ jobs:
         uses: actions/cache@v2
         with:
           path: /home/runner/.cache/bazel
-          key: bazel-gcc
+          key: bazel-gcc-${{ github.sha }}
+          restore-keys: bazel-gcc
 
       - run: sudo apt install -y build-essential
       - run: sudo wget https://github.com/bazelbuild/bazelisk/releases/latest/download/bazelisk-linux-amd64 -O /usr/local/bin/bazel
@@ -33,7 +34,8 @@ jobs:
         uses: actions/cache@v2
         with:
           path: /home/runner/.cache/bazel
-          key: bazel-gcc-instrumented
+          key: bazel-gcc-instrumented-${{ github.sha }}
+          restore-keys: bazel-gcc-instrumented
 
       - name: Print the list of targets
         run: bazel query --output label_kind //...
@@ -75,6 +77,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: /home/runner/.cache/bazel
-          key: bazel-clang-${{ steps.configure_llvm.outputs.clang_hash }}-${{ steps.configure_llvm.outputs.llvm_hash }}
+          key: bazel-clang-${{ steps.configure_llvm.outputs.clang_hash }}-${{ steps.configure_llvm.outputs.llvm_hash }}-${{ github.sha }}
+          restore-keys: bazel-clang-${{ steps.configure_llvm.outputs.clang_hash }}-${{ steps.configure_llvm.outputs.llvm_hash }}
 
       - run: bazel ${{ matrix.action }} --config=clang --test_tag_filters=-fixme --test_output=all -s //...


### PR DESCRIPTION
`Cache hit occurred on the primary key bazel-gcc, not saving cache.`

Github Actions skips cache uploading when there is a perfect key
match. This works well for other types of projects (e.g. dependency
cache), but not us, as we cache the compiled objects of our sources.

The cache should updated whenever the sources change, so this change
includes the current commit hash in the cache key, while generic key
is used as "restore-key".

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/masc-ucsc/livehd/215)
<!-- Reviewable:end -->
