### PR TITLE
deps: bump to masc-ucsc/bazel_rules_hdl@ce51c902d

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -143,9 +143,9 @@ http_archive(
 
 http_archive(
     name = "rules_hdl",
-    sha256 = "d76e41410f55596548efc18ec5ba6f947d4f8fafa64907904c787808dab3d00e",
-    strip_prefix = "bazel_rules_hdl-6214284faee7b4951c8f626c54dd1828f08cdd9d",
-    url = "https://github.com/masc-ucsc/bazel_rules_hdl/archive/6214284faee7b4951c8f626c54dd1828f08cdd9d.zip",
+    sha256 = "49956ac228faed57b783a971a6035d4251d26cc405ddc11bc489fbe3b013807e",
+    strip_prefix = "bazel_rules_hdl-ce51c902d25122977c8437f89bb146c4a83fc7e6",
+    url = "https://github.com/masc-ucsc/bazel_rules_hdl/archive/ce51c902d25122977c8437f89bb146c4a83fc7e6.zip",
 )
 
 load("@rules_hdl//toolchains/cpython:cpython_toolchain.bzl", "register_cpython_repository")


### PR DESCRIPTION
Deal with the troubles with newer glibc and GCC. 

Notable changes:

- masc-ucsc/bazel_rules_hdl@1736cd8c0cc695dcadb0c8b5c59b0f2dc485f3c0
- masc-ucsc/bazel_rules_hdl@1df026d4b03ab5a3b3d10b420f6bbc246f59ec1f

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/masc-ucsc/livehd/217)
<!-- Reviewable:end -->
