### PR TITLE
Portability improvements, bump to masc-ucsc/bazel_rules_hdl@c95d120

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -148,12 +148,6 @@ http_archive(
     url = "https://github.com/masc-ucsc/bazel_rules_hdl/archive/e8670bce1cf0ddc1da8fa97227da30306585ac34.zip",
 )
 
-load("@rules_hdl//toolchains/cpython:cpython_toolchain.bzl", "register_cpython_repository")
-
-register_cpython_repository()
-
-register_toolchains("@rules_hdl//toolchains/cpython:cpython_toolchain")
-
 load("@rules_hdl//dependency_support:dependency_support.bzl", "dependency_support")
 
 dependency_support()

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -14,7 +14,7 @@ http_archive(
 
 load("@rules_foreign_cc//:workspace_definitions.bzl", "rules_foreign_cc_dependencies")
 
-rules_foreign_cc_dependencies(register_preinstalled_tools = False)
+rules_foreign_cc_dependencies()
 
 new_git_repository(
     name = "mustache",

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -143,9 +143,9 @@ http_archive(
 
 http_archive(
     name = "rules_hdl",
-    sha256 = "1dd1ae619c6bce5d994de487bc43cf4c32f80187352826e66596ed8ec9a9058b",
-    strip_prefix = "bazel_rules_hdl-e8670bce1cf0ddc1da8fa97227da30306585ac34",
-    url = "https://github.com/masc-ucsc/bazel_rules_hdl/archive/e8670bce1cf0ddc1da8fa97227da30306585ac34.zip",
+    sha256 = "9fc01bddfaca00facc73fe8b39ef8f9c6885c60d0d3dea3c8289455591cb97dc",
+    strip_prefix = "bazel_rules_hdl-c95d1208144809afc6ed72a1cf2ab2694415c36e",
+    url = "https://github.com/masc-ucsc/bazel_rules_hdl/archive/c95d1208144809afc6ed72a1cf2ab2694415c36e.zip",
 )
 
 load("@rules_hdl//dependency_support:dependency_support.bzl", "dependency_support")

--- a/core/BUILD
+++ b/core/BUILD
@@ -12,7 +12,6 @@ cc_library(
     hdrs = glob(["*.hpp"]),
     copts = COPTS + ["-Wno-error=shadow"],
     includes = ["."],
-    linkopts = ["-lstdc++fs"],  # for gcc-8 or older
     visibility = ["//visibility:public"],
     deps = [
         "//eprp",

--- a/lgcpp/prplib/io.cpp
+++ b/lgcpp/prplib/io.cpp
@@ -1,14 +1,3 @@
 //  This file is distributed under the BSD 3-Clause License. See LICENSE for details.
 
 #include "lgcpp_plugin.hpp"
-
-static void lgcpp_test(Lgraph *lg, const std::shared_ptr<Lgtuple> inp, std::shared_ptr<Lgtuple> out) {
-  fmt::print("lgcpp_test called (compile time)\n");
-
-  (void)inp;
-  out       = std::make_shared<Lgtuple>("lgcc_var");
-  auto dpin = lg->create_node_const(33).get_driver_pin();
-  out->add(dpin);
-}
-
-static Lgcpp_plugin sample("lgcpp_test", lgcpp_test);

--- a/pass/compiler/lcompiler.cpp
+++ b/pass/compiler/lcompiler.cpp
@@ -2,8 +2,6 @@
 
 #include "lcompiler.hpp"
 
-#include <bits/stdint-uintn.h>
-
 Lcompiler::Lcompiler(std::string_view _path, std::string_view _odir, std::string_view _top, bool _gviz)
     : path(_path), odir(_odir), top(_top), gviz(_gviz), gv(true, false, _odir) {}
 

--- a/pass/compiler/lcompiler.hpp
+++ b/pass/compiler/lcompiler.hpp
@@ -1,6 +1,5 @@
 // This file is distributed under the BSD 3-Clause License. See LICENSE for details.
 #pragma once
-#include <bits/stdint-uintn.h>
 
 #include <mutex>
 #include <vector>

--- a/pass/compiler/pass_compiler.cpp
+++ b/pass/compiler/pass_compiler.cpp
@@ -1,8 +1,6 @@
 // This file is distributed under the BSD 3-Clause License. See LICENSE for details.
 #include "pass_compiler.hpp"
 
-#include <bits/stdint-uintn.h>
-
 #include <cstddef>
 
 #include "lcompiler.hpp"

--- a/pass/compiler/pass_compiler.hpp
+++ b/pass/compiler/pass_compiler.hpp
@@ -1,6 +1,5 @@
 // This file is distributed under the BSD 3-Clause License. See LICENSE for details.
 #pragma once
-#include <bits/stdint-uintn.h>
 
 #include <memory>
 #include <string>

--- a/pass/firmap/firbits.cpp
+++ b/pass/firmap/firbits.cpp
@@ -1,7 +1,5 @@
 //  This file is distributed under the BSD 3-Clause License. See LICENSE for details.
 
-#include <bits/stdint-uintn.h>
-
 #include <algorithm>
 #include <cmath>
 #include <vector>

--- a/pass/firmap/firmap.cpp
+++ b/pass/firmap/firmap.cpp
@@ -2,8 +2,6 @@
 
 #include "firmap.hpp"
 
-#include <bits/stdint-uintn.h>
-
 #include <algorithm>
 #include <cmath>
 #include <vector>

--- a/pass/firmap/firmap.hpp
+++ b/pass/firmap/firmap.hpp
@@ -1,8 +1,6 @@
 //  This file is distributed under the BSD 3-Clause License. See LICENSE for details.
 #pragma once
 
-#include <bits/stdint-uintn.h>
-
 #include "absl/container/node_hash_map.h"
 #include "lgedgeiter.hpp"
 #include "node.hpp"

--- a/pass/lnast_tolg/lnast_tolg.cpp
+++ b/pass/lnast_tolg/lnast_tolg.cpp
@@ -2,8 +2,6 @@
 
 #include "lnast_tolg.hpp"
 
-#include <bits/stdint-intn.h>
-
 #include <cctype>
 
 #include "cprop.hpp"

--- a/tools/copt_default.bzl
+++ b/tools/copt_default.bzl
@@ -8,6 +8,7 @@ COPTS = [
     "-Werror",
     "-Wno-error=deprecated-copy", # abseil/abseil-cpp#948
     "-Wno-unknown-pragmas",
+    "-Wno-error=deprecated",
     "-Wunused",
     "-Wshadow",
 ]


### PR DESCRIPTION
commit

    Disable "lgcpp_test" plugin
    
    It causes segfaults on some platforms.

commit

    deps: bump to masc-ucsc/bazel_rules_hdl@c95d12081

commit

    Drop unportable link to "stdc++fs"
    
    Now we mandate C++ 17 support, so this compat hack is not needed.
    
    It causes problems with newer platforms that remove the separate
    TS/exp filesystem library, and platforms that never have one.

commit

    Don't error on uses of deprecated functions
    
    libc++ is a lot stricter. While we can deal with deprecated functions
    in our codes, we can't deal with the ones in dependencies, so disable
    Werror for deprecated STL functions for now.

commit

    Drop unnecessary and GNU-specific "bits/stdint-uintn.h" includes

commit

    bazel: revert back to default Python toolchain (on the host)
    
    Prebuilt Python toolchain of rules_hdl only supports linux-x64.

commit

    bazel: allow to use tools on the host for foreign_cc
    
    Prebuilt binaries are not available for some platforms.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/masc-ucsc/livehd/227)
<!-- Reviewable:end -->
