### PR TITLE
Enhancing and Validating LiveHD's Power Modeling Flow

### DIFF
--- a/pass/opentimer/opentimer.cpp
+++ b/pass/opentimer/opentimer.cpp
@@ -515,7 +515,7 @@ void Pass_opentimer::compute_power(Lgraph *g) {  // Expand this method to comput
         pvcd.add(pin_name, ipwr + cap);
       }
 
-      // fmt::print("iname:{} pin:{} ipwr:{} cap:{}\n", instance_name, pin_name, ipwr, cap);
+      fmt::print("iname:{} pin:{} ipwr:{} cap:{}\n", instance_name, pin_name, ipwr, cap);
     }
   }
 

--- a/pass/opentimer/opentimer.cpp
+++ b/pass/opentimer/opentimer.cpp
@@ -476,7 +476,7 @@ void Pass_opentimer::compute_power(Lgraph *g) {  // Expand this method to comput
   for (auto &pvcd : vcd_list) {
     pvcd.set_tech_timeunit(timeunit);
   }
-
+  fmt::print("================================\n");
   for (const auto node : g->fast(true)) {
     auto op = node.get_type_op();
     if (op != Ntype_op::Sub) {
@@ -490,7 +490,7 @@ void Pass_opentimer::compute_power(Lgraph *g) {  // Expand this method to comput
       node.dump();
       fmt::print("WEIRD. Where is the gate? named {}\n", instance_name);
     }
-
+    
     for(const auto *pin:it2->second.pins()) {
       auto [cap, ipwr] = pin->power();
 
@@ -515,16 +515,18 @@ void Pass_opentimer::compute_power(Lgraph *g) {  // Expand this method to comput
         pvcd.add(pin_name, ipwr + cap);
       }
 
+      
       fmt::print("iname:{} pin:{} ipwr:{} cap:{}\n", instance_name, pin_name, ipwr, cap);
     }
   }
 
+  fmt::print("================================\n");
   for (auto &pvcd : vcd_list) {
     pvcd.compute(odir);
     fmt::print("AVG power:{} for {}\n", pvcd.get_power_average(), pvcd.get_filename());
   }
 
-  fmt::print("MAX power:{} switch:{} W internal:{} W voltage:{} V freq={}MHz\n"
+  fmt::print("TOTAL power:{} DYNAMIC power:{} INTERNAL power:{} W voltage:{} V freq={}MHz\n"
       ,total_cap+total_ipwr
       ,total_cap, total_ipwr
       ,voltage, freq/1e6);

--- a/pass/opentimer/power_vcd.cpp
+++ b/pass/opentimer/power_vcd.cpp
@@ -179,6 +179,12 @@ const char *Power_vcd::parse_instruction(const char *ptr) {
 const char *Power_vcd::parse_timestamp(const char *ptr) {
   auto [end_ptr, ec] = std::from_chars(ptr, map_end, timestamp, 10);
 
+  // Update num_vcd_cycles
+  if (ec == std::errc()) {
+    num_vcd_cycles = std::max(num_vcd_cycles, timestamp + 1);  // Adding 1 to count the cycle at this timestamp
+    fmt::print("VCD CYCLES {}\n", num_vcd_cycles);
+  }
+
   // fmt::print("timestamp:{}\n", timestamp);
 
   return end_ptr;

--- a/pass/opentimer/power_vcd.cpp
+++ b/pass/opentimer/power_vcd.cpp
@@ -182,7 +182,6 @@ const char *Power_vcd::parse_timestamp(const char *ptr) {
   // Update num_vcd_cycles
   if (ec == std::errc()) {
     num_vcd_cycles = std::max(num_vcd_cycles, timestamp + 1);  // Adding 1 to count the cycle at this timestamp
-    fmt::print("VCD CYCLES {}\n", num_vcd_cycles);
   }
 
   // fmt::print("timestamp:{}\n", timestamp);

--- a/pass/opentimer/power_vcd.hpp
+++ b/pass/opentimer/power_vcd.hpp
@@ -1,4 +1,5 @@
 //  This file is distributed under the BSD 3-Clause License. See LICENSE for details.
+#include <iostream>
 
 #include <sys/mman.h>
 
@@ -22,6 +23,7 @@ protected:
   double timescale{1e-12};
   double lib_timescale{1e-9};
   size_t n_buckets{100};
+  size_t num_vcd_cycles{0};
 
   int         map_fd{-1};
   const char *map_buffer{nullptr};
@@ -57,7 +59,15 @@ protected:
   absl::node_hash_map<std::string, Channel> id2channel;
   absl::flat_hash_map<std::string, double> net_hier_name2power;
 
-  [[nodiscard]] size_t get_current_bucket() const { return (n_buckets * timestamp) / max_timestamp; }
+  [[nodiscard]] size_t get_current_bucket() const {
+    if (num_vcd_cycles < n_buckets) {
+         std::cout << "VCD < BUCKET" << std::endl;
+        return timestamp;
+    } else {
+      std::cout << "VCD > BUCKET" << std::endl;
+        return (n_buckets * timestamp) / max_timestamp;
+    }
+  }
 
   bool                                      find_max_time();
   const char                               *skip_command(const char *ptr) const;

--- a/pass/opentimer/power_vcd.hpp
+++ b/pass/opentimer/power_vcd.hpp
@@ -61,10 +61,8 @@ protected:
 
   [[nodiscard]] size_t get_current_bucket() const {
     if (num_vcd_cycles < n_buckets) {
-         std::cout << "VCD < BUCKET" << std::endl;
         return timestamp;
     } else {
-      std::cout << "VCD > BUCKET" << std::endl;
         return (n_buckets * timestamp) / max_timestamp;
     }
   }

--- a/pass/opentimer/tests/test_and2_inv.v
+++ b/pass/opentimer/tests/test_and2_inv.v
@@ -1,0 +1,41 @@
+module test_and2(clk, in1, in2, out);
+  input  clk; // Not used but for easier verilator common flow
+  input  in1;
+  input  in2;
+  output out;
+
+  wire  in1_buf, in1_not;
+  wire  in2_buf, in2_not;
+  wire  out_not;
+
+  sky130_fd_sc_hd__inv_1 inv1 (
+    .A(in1),
+    .Y(in1_not)
+  );
+
+  sky130_fd_sc_hd__inv_1 inv2 (
+    .A(in2),
+    .Y(in2_not)
+  );
+
+  sky130_fd_sc_hd__buf_1 gin1 (
+    .A(in1_not),
+    .X(in1_buf)
+  );
+
+  sky130_fd_sc_hd__buf_1 gin2 (
+    .A(in2_not),
+    .X(in2_buf)
+  );
+
+  sky130_fd_sc_hd__and2_1 icg (
+    .A(in1_buf),
+    .B(in2_buf),
+    .X(out_not)
+  );
+
+  sky130_fd_sc_hd__inv_1 invOut (
+    .A(out_not),
+    .Y(out)
+  );
+endmodule

--- a/pass/opentimer/tests/test_and2_or.v
+++ b/pass/opentimer/tests/test_and2_or.v
@@ -1,0 +1,68 @@
+module test_and2(clk, in1, in2, out);
+  input  clk; // Not used but for easier verilator common flow
+  input  in1;
+  input  in2;
+  output out;
+
+  wire  x, y;
+  wire  z0, z1;
+  wire  z;
+  wire  in1_buf;
+  wire  in2_buf;
+
+  sky130_fd_sc_hd__inv_1 inv1 (
+    .A(in1),
+    .Y(in1_buf)
+  );
+
+  sky130_fd_sc_hd__inv_1 inv2 (
+    .A(in2),
+    .Y(in2_buf)
+  );
+
+  sky130_fd_sc_hd__buf_1 gin1 (
+    .A(in1_buf),
+    .X(x)
+  );
+
+  sky130_fd_sc_hd__buf_1 gin2 (
+    .A(in2_buf),
+    .X(y)
+  );
+
+  sky130_fd_sc_hd__and2_1 and_gate (
+    .A(x),
+    .B(y),
+    .X(z0)
+  );
+
+  sky130_fd_sc_hd__or2_1 or_gate (
+    .A(x),
+    .B(y),
+    .X(z1)
+  );
+
+  sky130_fd_sc_hd__and2_1 and_gate2 (
+    .A(z0),
+    .B(z1),
+    .X(z)
+  );
+
+  sky130_fd_sc_hd__inv_1 invOut (
+    .A(z),
+    .Y(out)
+  );
+
+endmodule
+
+
+/*
+The Algorithm for this test is as follows
+
+x = not(inp1)
+y = not(inp2)
+z0 = and(x,y)
+z1 = or(x,y)
+z = and(z0,z1)
+out = not(z)
+*/

--- a/pass/opentimer/tests/test_and2_or_xor.v
+++ b/pass/opentimer/tests/test_and2_or_xor.v
@@ -1,0 +1,178 @@
+module test_and2(clk, in1, in2, out);
+  input  clk; // Not used but for easier verilator common flow
+  input  in1;
+  input  in2;
+  output out;
+
+  wire x, y;
+  wire z0, z1, z2, z3, z4, z5, z6, z7, z8, z9, z10;
+  wire out1, out2, out3, out4, out5;
+  wire  in1_buf;
+  wire  in2_buf;
+
+  // Compute x = NOT(inp1)
+  sky130_fd_sc_hd__inv_1 inv1 (
+    .A(in1),
+    .Y(in1_buf)
+  );
+
+  // Compute y = NOT(inp2)
+  sky130_fd_sc_hd__inv_1 inv2 (
+    .A(in2),
+    .Y(in2_buf)
+  );
+
+  sky130_fd_sc_hd__buf_1 gin1 (
+    .A(in1_buf),
+    .X(x)
+  );
+
+  sky130_fd_sc_hd__buf_1 gin2 (
+    .A(in2_buf),
+    .X(y)
+  );
+
+  // z0 = AND(x,y)
+  sky130_fd_sc_hd__and2_1 and1 (
+    .A(x),
+    .B(y),
+    .X(z0)
+  );
+
+  // z1 = OR(x,y)
+  sky130_fd_sc_hd__or2_1 or1 (
+    .A(x),
+    .B(y),
+    .X(z1)
+  );
+
+  // z2 = AND(z0,z1)
+  sky130_fd_sc_hd__and2_1 and2 (
+    .A(z0),
+    .B(z1),
+    .X(z2)
+  );
+
+  // out1 = NOT(z2)
+  sky130_fd_sc_hd__inv_1 inv3 (
+    .A(z2),
+    .Y(out1)
+  );
+
+  // z3 = AND(out1, x)
+  sky130_fd_sc_hd__and2_1 and3 (
+    .A(out1),
+    .B(x),
+    .X(z3)
+  );
+
+  // z4 = OR(z2,y)
+  sky130_fd_sc_hd__or2_1 or2 (
+    .A(z2),
+    .B(y),
+    .X(z4)
+  );
+
+  // out2 = NOT(z3)
+  sky130_fd_sc_hd__inv_1 inv4 (
+    .A(z3),
+    .Y(out2)
+  );
+
+  // z5 = XOR(out1, out2)
+  sky130_fd_sc_hd__xor2_1 xor1 (
+    .A(out1),
+    .B(out2),
+    .X(z5)
+  );
+
+  // z6 = AND(z4, z3)
+  sky130_fd_sc_hd__and2_1 and4 (
+    .A(z4),
+    .B(z3),
+    .X(z6)
+  );
+
+  // out3 = NOT(z5)
+  sky130_fd_sc_hd__inv_1 inv5 (
+    .A(z5),
+    .Y(out3)
+  );
+
+  // z7 = OR(out3, z2)
+  sky130_fd_sc_hd__or2_1 or3 (
+    .A(out3),
+    .B(z2),
+    .X(z7)
+  );
+
+  // z8 = XOR(z6, z5)
+  sky130_fd_sc_hd__xor2_1 xor2 (
+    .A(z6),
+    .B(z5),
+    .X(z8)
+  );
+
+  // out4 = NOT(z7)
+  sky130_fd_sc_hd__inv_1 inv6 (
+    .A(z7),
+    .Y(out4)
+  );
+
+  // z9 = AND(out4, z4)
+  sky130_fd_sc_hd__and2_1 and5 (
+    .A(out4),
+    .B(z4),
+    .X(z9)
+  );
+
+  // z10 = OR(z8, z7)
+  sky130_fd_sc_hd__or2_1 or4 (
+    .A(z8),
+    .B(z7),
+    .X(z10)
+  );
+
+  // out5 = XOR(z9, z10)
+  sky130_fd_sc_hd__xor2_1 xor3 (
+    .A(z9),
+    .B(z10),
+    .X(out5)
+  );
+
+  // Final output
+  sky130_fd_sc_hd__inv_1 invOut (
+    .A(out5),
+    .Y(out)
+  );
+endmodule
+
+
+/*
+The Algorithm for this test is as follows
+
+x = not(inp1)
+y = not(inp2)
+z0 = and(x, y)
+z1 = or(x, y)
+z2 = and(z0, z1)
+out1 = not(z2)
+
+z3 = and(out1, x)
+z4 = or(z2, y)
+out2 = not(z3)
+
+z5 = xor(out1, out2)
+z6 = and(z4, z3)
+out3 = not(z5)
+
+z7 = or(out3, z2)
+z8 = xor(z6, z5)
+out4 = not(z7)
+
+z9 = and(out4, z4)
+z10 = or(z8, z7)
+out5 = xor(z9, z10)
+
+out = not(out5)
+*/

--- a/pass/opentimer/tests/test_and2_or_xor_3in.v
+++ b/pass/opentimer/tests/test_and2_or_xor_3in.v
@@ -1,0 +1,183 @@
+module test_and2(clk, in1, in2, out);
+  input  clk; // Not used but for easier verilator common flow
+  input  in1;
+  input  in2;
+  output out;
+
+  wire x, y;
+  wire z0, z1, z2, z3, z4, z5, z6, z7, z8, z9, z10;
+  wire out1, out2, out3, out4, out5;
+  wire  in1_buf;
+  wire  in2_buf;
+
+  // Compute x = NOT(inp1)
+  sky130_fd_sc_hd__inv_1 inv1 (
+    .A(in1),
+    .Y(in1_buf)
+  );
+
+  // Compute y = NOT(inp2)
+  sky130_fd_sc_hd__inv_1 inv2 (
+    .A(in2),
+    .Y(in2_buf)
+  );
+
+  sky130_fd_sc_hd__buf_1 gin1 (
+    .A(in1_buf),
+    .X(x)
+  );
+
+  sky130_fd_sc_hd__buf_1 gin2 (
+    .A(in2_buf),
+    .X(y)
+  );
+
+
+  // z0 = AND(x,y)
+  sky130_fd_sc_hd__and2_1 and1 (
+    .A(x),
+    .B(y),
+    .X(z0)
+  );
+
+  // z1 = OR(x,y)
+  sky130_fd_sc_hd__or2_1 or1 (
+    .A(x),
+    .B(y),
+    .X(z1)
+  );
+
+  // z2 = AND(z0,z1,x)
+  sky130_fd_sc_hd__and3_1 and2 (
+    .A(z0),
+    .B(z1),
+    .C(x),
+    .X(z2)
+  );
+
+  // out1 = NOT(z2)
+  sky130_fd_sc_hd__inv_1 inv3 (
+    .A(z2),
+    .Y(out1)
+  );
+
+  // z3 = AND(out1, x)
+  sky130_fd_sc_hd__and2_1 and3 (
+    .A(out1),
+    .B(x),
+    .X(z3)
+  );
+
+  // z4 = OR(z2,y,z3)
+  sky130_fd_sc_hd__or3_1 or2 (
+    .A(z2),
+    .B(y),
+    .C(z3),
+    .X(z4)
+  );
+
+  // out2 = NOT(z3)
+  sky130_fd_sc_hd__inv_1 inv4 (
+    .A(z3),
+    .Y(out2)
+  );
+
+  // z5 = XOR(out1, out2)
+  sky130_fd_sc_hd__xor2_1 xor1 (
+    .A(out1),
+    .B(out2),
+    .X(z5)
+  );
+
+  // z6 = AND(z4, z3, z5)
+  sky130_fd_sc_hd__and3_1 and4 (
+    .A(z4),
+    .B(z3),
+    .C(z5),
+    .X(z6)
+  );
+
+  // out3 = NOT(z5)
+  sky130_fd_sc_hd__inv_1 inv5 (
+    .A(z5),
+    .Y(out3)
+  );
+
+  // z7 = OR(out3, z2)
+  sky130_fd_sc_hd__or2_1 or3 (
+    .A(out3),
+    .B(z2),
+    .X(z7)
+  );
+
+  // z8 = XOR(z6, z5, z7)
+  sky130_fd_sc_hd__xor3_1 xor2 (
+    .A(z6),
+    .B(z5),
+    .C(z7),
+    .X(z8)
+  );
+
+  // out4 = NOT(z7)
+  sky130_fd_sc_hd__inv_1 inv6 (
+    .A(z7),
+    .Y(out4)
+  );
+
+  // z9 = AND(out4, z4)
+  sky130_fd_sc_hd__and2_1 and5 (
+    .A(out4),
+    .B(z4),
+    .X(z9)
+  );
+
+  // z10 = OR(z8, z7, z9)
+  sky130_fd_sc_hd__or3_1 or4 (
+    .A(z8),
+    .B(z7),
+    .C(z9),
+    .X(z10)
+  );
+
+  // out5 = XOR(z9, z10)
+  sky130_fd_sc_hd__xor2_1 xor3 (
+    .A(z9),
+    .B(z10),
+    .X(out5)
+  );
+
+  // Final output
+  sky130_fd_sc_hd__inv_1 invOut (
+    .A(out5),
+    .Y(out)
+  );
+endmodule
+
+/*
+The Algorithm for this test is as follows
+
+x = not(inp1)
+y = not(inp2)
+z0 = and(x, y)
+z1 = or(x, y)
+z2 = and(z0, z1, x)   # 3 input and
+out1 = not(z2)
+
+z3 = and(out1, x)
+z4 = or(z2, y, z3)    # 3 input or
+out2 = not(z3)
+
+z5 = xor(out1, out2)
+z6 = and(z4, z3, z5) # 3 input and
+out3 = not(z5)
+
+z7 = or(out3, z2)
+z8 = xor(z6, z5, z7)  # 3 input xor
+out4 = not(z7)
+
+z9 = and(out4, z4)
+z10 = or(z8, z7, z9)   # 3 input or
+out5 = xor(z9, z10)
+
+out = not(out5)
+*/


### PR DESCRIPTION
This PR contains the following changes

- power log for each gate enabled
- added logic to compute power when `vcd cycles < n_buckets`
- more example netlists added in `pass/opetimer/tests`
- changed power labels to have more consistent names

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/masc-ucsc/livehd/384)
<!-- Reviewable:end -->
