### PR TITLE
upass/constprop: §5.a Symbol_table query API + arithmetic guards

### DIFF
--- a/lnast/symbol_table.cpp
+++ b/lnast/symbol_table.cpp
@@ -158,6 +158,12 @@ std::shared_ptr<Bundle> Symbol_table::leave_scope() {
   return outputs;
 }
 
+bool Symbol_table::is_known_const(std::string_view name) const {
+  if (!has_trivial(name)) return false;
+  const auto& val = get_trivial(name);
+  return !val.is_invalid() && !val.has_unknowns();
+}
+
 bool Symbol_table::has_trivial(std::string_view key) const {
   auto [var, field] = get_var_field(key);
 

--- a/lnast/symbol_table.hpp
+++ b/lnast/symbol_table.hpp
@@ -45,6 +45,19 @@ public:
   bool has_bundle(std::string_view key) const;
   bool has_known(std::string_view key) const { return has_trivial(key) || has_bundle(key); }
 
+  /// Returns true iff `name` holds a concrete Lconst with no unknown bits.
+  bool is_known_const(std::string_view name) const;
+
+  /// Slice-1 stand-in: true iff `name` starts with '#' (register prefix).
+  /// Migrates to ST-backed lookup after lnast_todo.md §12.
+  bool is_reg(std::string_view name) const { return !name.empty() && name.front() == '#'; }
+
+  /// Slice-1 stand-in: true iff `name` starts with '$' (input-port prefix).
+  bool is_input(std::string_view name) const { return !name.empty() && name.front() == '$'; }
+
+  /// Slice-1 stand-in: true iff `name` starts with '%' (output-port prefix).
+  bool is_output(std::string_view name) const { return !name.empty() && name.front() == '%'; }
+
   // Lconst can be 0sb? or 123 or string or bool or nil or runtime (0sb? and runtime?)
   const Lconst&           get_trivial(std::string_view key) const;
   std::shared_ptr<Bundle> get_bundle(std::string_view key) const;

--- a/upass/constprop/upass_constprop.cpp
+++ b/upass/constprop/upass_constprop.cpp
@@ -74,8 +74,20 @@ void uPass_constprop::process_nary(F op) {
   auto var = current_text();
   move_to_sibling();
   Lconst r = current_prim_value();
+
+  // Skip folding if any operand is unknown, a non-numeric string, or has X-bits.
+  // Arithmetic on invalid/string Lconst values is undefined and will crash.
+  if (r.is_invalid() || r.is_string() || r.has_unknowns()) {
+    move_to_parent();
+    return;
+  }
   while (move_to_sibling()) {
-    op(r, current_prim_value());
+    auto operand = current_prim_value();
+    if (operand.is_invalid() || operand.is_string() || operand.has_unknowns()) {
+      move_to_parent();
+      return;
+    }
+    op(r, operand);
   }
   bool local_changed = true;
   if (st.has_trivial(var)) {
@@ -96,9 +108,20 @@ void uPass_constprop::process_binary(F op) {
   move_to_sibling();
   Lconst n1 = current_prim_value();
   move_to_sibling();
-  Lconst n2            = current_prim_value();
-  Lconst r             = op(n1, n2);
-  bool   local_changed = true;
+  Lconst n2 = current_prim_value();
+
+  // Skip folding if either operand is unknown, non-numeric, or has X-bits.
+  if (n1.is_invalid() || n1.is_string() || n1.has_unknowns() ||
+      n2.is_invalid() || n2.is_string() || n2.has_unknowns()) {
+    move_to_parent();
+    return;
+  }
+  Lconst r = op(n1, n2);
+  if (r.is_invalid()) {
+    move_to_parent();
+    return;
+  }
+  bool local_changed = true;
   if (st.has_trivial(var)) {
     local_changed = st.get_trivial(var) != r;
   }
@@ -116,6 +139,12 @@ void uPass_constprop::process_unary(F op) {
   auto var = current_text();
   move_to_sibling();
   Lconst r = current_prim_value();
+
+  // Skip folding if input is unknown, non-numeric, or has X-bits.
+  if (r.is_invalid() || r.is_string() || r.has_unknowns()) {
+    move_to_parent();
+    return;
+  }
   op(r);
   bool local_changed = true;
   if (st.has_trivial(var)) {
@@ -173,11 +202,17 @@ void uPass_constprop::process_mod() {
 }
 
 void uPass_constprop::process_shl() {
-  process_binary([](Lconst n1, Lconst n2) { return n1.lsh_op(static_cast<Bits_t>(n2.to_i())); });
+  process_binary([](Lconst n1, Lconst n2) -> Lconst {
+    if (!n2.is_i()) return Lconst::invalid();
+    return n1.lsh_op(static_cast<Bits_t>(n2.to_i()));
+  });
 }
 
 void uPass_constprop::process_sra() {
-  process_binary([](Lconst n1, Lconst n2) { return n1.rsh_op(static_cast<Bits_t>(n2.to_i())); });
+  process_binary([](Lconst n1, Lconst n2) -> Lconst {
+    if (!n2.is_i()) return Lconst::invalid();
+    return n1.rsh_op(static_cast<Bits_t>(n2.to_i()));
+  });
 }
 
 void uPass_constprop::process_log_and() {
@@ -297,9 +332,73 @@ void uPass_constprop::process_tuple_add() {
 }
 
 void uPass_constprop::process_tuple_concat() {
-  // n-ary concat: ref(dst), (const|ref)...
-  // Fold when every source operand is a known scalar (string or integer).
-  process_nary([](Lconst& r, Lconst n) { r = r.concat_op(n); });
+  // Layout: ref(dst), (const|ref)...
+  // Two modes determined by the first operand:
+  //   Bundle mode  — every operand must be a known Bundle; merged via Bundle::concat().
+  //                  No mark_changed — convergence via downstream tuple_get (same as tuple_add).
+  //   Scalar mode  — every operand must be a known scalar; folded via Lconst::concat_op.
+  // Bail without folding when any operand is truly unknown or types are mixed.
+  move_to_child();
+  auto dst = std::string(current_text());
+
+  if (!move_to_sibling()) {
+    move_to_parent();
+    return;
+  }
+
+  bool                    bundle_mode = false;
+  std::shared_ptr<Bundle> acc_bundle;
+  Lconst                  acc_scalar;
+  bool                    is_first = true;
+
+  auto process_one = [&]() -> bool {
+    if (is_type(Lnast_ntype::Lnast_ntype_ref)) {
+      auto b = st.get_bundle(current_text());
+      if (b) {
+        if (!is_first && !bundle_mode) return false;
+        if (is_first) {
+          acc_bundle  = std::make_shared<Bundle>(dst);
+          bundle_mode = true;
+        }
+        acc_bundle->concat(b);
+        return true;
+      }
+      if (st.has_trivial(current_text())) {
+        auto val = st.get_trivial(current_text());
+        if (val.is_invalid() || val.has_unknowns() || bundle_mode) return false;
+        acc_scalar = is_first ? val : acc_scalar.concat_op(val);
+        return true;
+      }
+      return false;
+    }
+    if (is_type(Lnast_ntype::Lnast_ntype_const)) {
+      if (bundle_mode) return false;
+      auto val = Lconst::from_pyrope(current_text());
+      if (val.is_invalid()) return false;
+      acc_scalar = is_first ? val : acc_scalar.concat_op(val);
+      return true;
+    }
+    return false;
+  };
+
+  do {
+    if (!process_one()) {
+      move_to_parent();
+      return;
+    }
+    is_first = false;
+  } while (move_to_sibling());
+
+  move_to_parent();
+
+  if (bundle_mode) {
+    st.set(dst, acc_bundle);
+  } else {
+    bool local_changed = !st.has_trivial(dst) || st.get_trivial(dst) != acc_scalar;
+    if (local_changed && st.set(dst, acc_scalar)) {
+      mark_changed();
+    }
+  }
 }
 
 void uPass_constprop::process_func_call() {
@@ -674,20 +773,15 @@ upass::Emit_decision uPass_constprop::classify_statement() {
     return upass::Emit_decision::emit_node();
   }
 
-  // Regs, inputs, outputs carry semantics beyond value. Keep.
-  const char c0 = lhs_text.front();
-  if (c0 == '#' || c0 == '$' || c0 == '%') {
+  // Regs, inputs, and outputs carry timing/boundary semantics beyond value — always emit.
+  // Slice-1 prefix check; migrates to st.is_reg/is_input/is_output after §12.
+  if (st.is_reg(lhs_text) || st.is_input(lhs_text) || st.is_output(lhs_text)) {
     return upass::Emit_decision::emit_node();
   }
 
-  // Symbol table uses the stripped name (process_assign already strips
-  // leading %/$ on assignment — see upass_constprop.cpp::process_assign).
-  // Here we've already rejected those cases, so lhs_text is the key.
-  if (!st.has_trivial(lhs_text)) {
-    return upass::Emit_decision::emit_node();
-  }
-  const auto val = st.get_trivial(lhs_text);
-  if (val.is_invalid() || val.has_unknowns()) {
+  // Drop iff the ST holds a fully-known value. is_known_const() encapsulates
+  // has_trivial + is_invalid + has_unknowns in one call.
+  if (!st.is_known_const(lhs_text)) {
     return upass::Emit_decision::emit_node();
   }
 
@@ -698,20 +792,15 @@ std::optional<Lconst> uPass_constprop::fold_ref(std::string_view name) {
   if (name.empty()) {
     return std::nullopt;
   }
-  // Match the stripping in process_assign so lookups against %foo / $foo
-  // resolve the same entry the writer populated.
+  // Strip I/O prefixes so the lookup matches what process_assign stored.
   std::string_view key = name;
-  if (key.front() == '%' || key.front() == '$') {
+  if (st.is_input(key) || st.is_output(key)) {
     key.remove_prefix(1);
   }
-  if (!st.has_trivial(key)) {
+  if (!st.is_known_const(key)) {
     return std::nullopt;
   }
-  auto val = st.get_trivial(key);
-  if (val.is_invalid() || val.has_unknowns()) {
-    return std::nullopt;
-  }
-  return val;
+  return st.get_trivial(key);
 }
 
 void uPass_constprop::process_sext() {

--- a/upass/constprop/upass_constprop_test.cpp
+++ b/upass/constprop/upass_constprop_test.cpp
@@ -27,6 +27,18 @@ public:
 
   // Pre-populate the symbol table so process_if() can look up conditions.
   void seed(std::string_view name, const Lconst& val) { st.set(name, val); }
+
+  // Expose §5.a ST query helpers for testing.
+  bool st_is_known_const(std::string_view name) const { return st.is_known_const(name); }
+  bool st_is_reg(std::string_view name)         const { return st.is_reg(name); }
+  bool st_is_input(std::string_view name)       const { return st.is_input(name); }
+  bool st_is_output(std::string_view name)      const { return st.is_output(name); }
+
+  // Directly write a trivial value into the symbol table (for ST tests).
+  void st_set(std::string_view name, const Lconst& val) { st.set(name, val); }
+
+  // Expose classify_statement() for white-box testing.
+  upass::Emit_decision classify() { return classify_statement(); }
 };
 
 // Build a fresh Lnast and Lnast_manager for each test.
@@ -694,6 +706,101 @@ TEST(UpassConstpropTuple, TupleSetThenGetRoundTrip) {
   cp.process_tuple_get();  // dst = ___t0[0] = 77
 
   EXPECT_EQ(cp.get_result("dst").to_i(), 77);
+}
+
+// ─── Symbol_table query API (§5.a) ──────────────────────────────────────────
+
+// is_known_const returns true when the variable holds a concrete, fully-known Lconst.
+TEST(UpassConstpropST, IsKnownConstWithValidValue) {
+  ConstpropFixture  f;
+  TestableConstprop cp(f.lm);
+
+  cp.st_set("x", Lconst(42));
+  EXPECT_TRUE(cp.st_is_known_const("x"));
+}
+
+// is_known_const returns false when the variable has never been declared.
+TEST(UpassConstpropST, IsKnownConstAbsentReturnsFalse) {
+  ConstpropFixture  f;
+  TestableConstprop cp(f.lm);
+
+  EXPECT_FALSE(cp.st_is_known_const("no_such_var"));
+}
+
+// is_known_const returns false when the stored value is Lconst::invalid().
+TEST(UpassConstpropST, IsKnownConstInvalidLconstReturnsFalse) {
+  ConstpropFixture  f;
+  TestableConstprop cp(f.lm);
+
+  cp.st_set("y", Lconst::invalid());
+  EXPECT_FALSE(cp.st_is_known_const("y"));
+}
+
+// is_reg correctly identifies '#'-prefixed names as registers.
+TEST(UpassConstpropST, IsRegDetectsHashPrefix) {
+  ConstpropFixture  f;
+  TestableConstprop cp(f.lm);
+
+  EXPECT_TRUE(cp.st_is_reg("#counter"));
+  EXPECT_FALSE(cp.st_is_reg("counter"));
+  EXPECT_FALSE(cp.st_is_reg("$inp"));
+  EXPECT_FALSE(cp.st_is_reg(""));
+}
+
+// is_input correctly identifies '$'-prefixed names as input ports.
+TEST(UpassConstpropST, IsInputDetectsDollarPrefix) {
+  ConstpropFixture  f;
+  TestableConstprop cp(f.lm);
+
+  EXPECT_TRUE(cp.st_is_input("$inp"));
+  EXPECT_FALSE(cp.st_is_input("inp"));
+  EXPECT_FALSE(cp.st_is_input("#reg"));
+  EXPECT_FALSE(cp.st_is_input(""));
+}
+
+// is_output correctly identifies '%'-prefixed names as output ports.
+TEST(UpassConstpropST, IsOutputDetectsPercentPrefix) {
+  ConstpropFixture  f;
+  TestableConstprop cp(f.lm);
+
+  EXPECT_TRUE(cp.st_is_output("%out"));
+  EXPECT_FALSE(cp.st_is_output("out"));
+  EXPECT_FALSE(cp.st_is_output("$inp"));
+  EXPECT_FALSE(cp.st_is_output(""));
+}
+
+// classify_statement drops an assign whose LHS is a known-const temp variable.
+TEST(UpassConstpropST, ClassifyDropsKnownConstTemp) {
+  ConstpropFixture f;
+
+  // Build:  ___tmp = 7
+  auto assign_op = f.ln->add_child(f.stmts_nid, Lnast_node::create_assign());
+  f.ln->add_child(assign_op, Lnast_node::create_ref("___tmp"));
+  f.ln->add_child(assign_op, Lnast_node::create_const("7"));
+
+  TestableConstprop cp(f.lm);
+  cp.st_set("___tmp", Lconst(7));
+
+  cp.position(assign_op);
+  auto decision = cp.classify();
+  EXPECT_EQ(decision.kind, upass::Emit_kind::drop_subtree);
+}
+
+// classify_statement emits a register assignment even when the value is known.
+TEST(UpassConstpropST, ClassifyKeepsRegEvenIfKnownConst) {
+  ConstpropFixture f;
+
+  // Build:  #reg = 7
+  auto assign_op = f.ln->add_child(f.stmts_nid, Lnast_node::create_assign());
+  f.ln->add_child(assign_op, Lnast_node::create_ref("#reg"));
+  f.ln->add_child(assign_op, Lnast_node::create_const("7"));
+
+  TestableConstprop cp(f.lm);
+  cp.st_set("#reg", Lconst(7));
+
+  cp.position(assign_op);
+  auto decision = cp.classify();
+  EXPECT_EQ(decision.kind, upass::Emit_kind::emit);
 }
 
 }  // namespace


### PR DESCRIPTION
## Summary

- **Symbol_table query API (§5.a):** Add `is_known_const()`, `is_reg()`, `is_input()`, `is_output()` to `Symbol_table` — Slice-1 prefix-based stand-ins (`#`/`$`/`%`) that migrate to full ST lookup after lnast_todo.md §12.
- **`classify_statement()` / `fold_ref()`:** Wire the new helpers in so known-const temp variables are dropped from the emit graph while registers and I/O ports are always preserved.
- **Arithmetic safety guards:** Add `is_invalid() || is_string() || has_unknowns()` early-exit guards to all three `process_nary` / `process_binary` / `process_unary` templates, and `is_i()` guards for SHL/SRA.
- **`process_tuple_concat()` rewrite:** Two-mode loop — Bundle operands merged via `Bundle::concat()`; scalar operands folded via `Lconst::concat_op()`.
- **8 new GTests:** `UpassConstpropST.*` suite covering `is_known_const`, `is_reg`, `is_input`, `is_output`, classify drop/emit decisions. `TestableConstprop` gains `st_set` / `classify` / `st_is_*` white-box helpers.

## Files changed

| File | Change |
|---|---|
| `lnast/symbol_table.hpp` | +`is_known_const` decl + 3 inline prefix helpers |
| `lnast/symbol_table.cpp` | +`is_known_const` implementation |
| `upass/constprop/upass_constprop.cpp` | arithmetic guards, SHL/SRA `is_i()`, `process_tuple_concat` rewrite, `classify_statement`/`fold_ref` wiring |
| `upass/constprop/upass_constprop_test.cpp` | `TestableConstprop` helpers + 8 new GTests |

## Test plan

- [ ] `CC=clang-21 CXX=clang++-21 bazel test //upass/constprop/... --test_output=all` — all GTests green
- [ ] `bazel test //inou/prp/... --test_output=streamed` — comptime cassert suite passes at least the existing baseline (11/51)
- [ ] No files outside the 4 above appear in the diff against `masc-ucsc/livehd:master`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/masc-ucsc/livehd/531)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Constant propagation optimization is now more robust, correctly handling invalid or unknown values without unsafe folding
  * Enhanced arithmetic and shift operations with stricter input validation
  * Expanded concatenation support with improved type consistency checks
  * Tightened statement emission logic for more accurate optimization decisions

* **Tests**
  * Added comprehensive test coverage for constant propagation edge cases and symbol table queries

<!-- end of auto-generated comment: release notes by coderabbit.ai -->