### PR TITLE
upass/runner: Slice 7 — if-branch pruning (dead-branch elimination)

### DIFF
--- a/upass/constprop/upass_constprop.cpp
+++ b/upass/constprop/upass_constprop.cpp
@@ -251,9 +251,9 @@ void uPass_constprop::process_ge() {
 }
 
 void uPass_constprop::process_if() {
-  // Conservative if-handling: inspect condition variables but always let the
-  // runner traverse all branches.
-  // Dead-branch elimination requires tree-surgery hooks not yet in the runner.
+  // Observe the condition so the symbol table is populated before the runner
+  // queries try_fold_ref(). The runner's process_if (Slice 7) performs the
+  // actual dead-branch elimination based on the folded condition value.
   if (!move_to_child()) {
     return;
   }

--- a/upass/runner/BUILD
+++ b/upass/runner/BUILD
@@ -27,6 +27,7 @@ cc_test(
     copts = COPTS,
     deps = [
         ":upass_runner",
+        "//upass/constprop:upass_constprop",
         "@googletest//:gtest_main",
     ],
 )

--- a/upass/runner/upass_runner.cpp
+++ b/upass/runner/upass_runner.cpp
@@ -520,7 +520,16 @@ void uPass_runner::process_if() {
               return;                // pruned
             }
             // elif chain (next sibling is another condition, not stmts): fall
-            // through to full-if emit. Recursive elif pruning is a future task.
+            // through to full-if emit.  Recursive elif pruning is a future task.
+            //
+            // KNOWN LIMITATION (flagged by PR review): dispatch_to_passes above
+            // has already let constprop walk the *entire* if subtree, so its ST
+            // now contains writes from the (statically-unreached) then-branch.
+            // When process_lnast() below recurses into the elif/else bodies,
+            // classify_statement may incorrectly DCE a live write whose LHS was
+            // already recorded in the ST from that dead branch.  Safe to defer
+            // until elif pruning is implemented; track against the test suite
+            // as elif coverage grows.  (See upass.md §Slice 7 TODO.)
           } else {
             // No else-stmts: false condition → emit nothing.
             lm->move_to_parent();  // back to if-node

--- a/upass/runner/upass_runner.cpp
+++ b/upass/runner/upass_runner.cpp
@@ -466,9 +466,74 @@ void uPass_runner::process_stmts() {
 }
 
 void uPass_runner::process_if() {
-  // Dispatch first so passes can inspect the condition before we emit.
+  // Dispatch first so passes can update their symbol tables from the condition.
   dispatch_to_passes(&upass::uPass::process_if);
 
+  // Slice 7 — dead-branch elimination.
+  // When the first child is a comptime-known condition (ref or const), emit
+  // only the taken branch's stmts spliced into the parent (no if node).
+  // Cursor invariant: must be at the if-node on all exit paths.  // See upass.md §Slice 7 and §5 (if cursor discipline).
+  if (lm->has_child()) {
+    lm->move_to_child();
+    using Ntype        = Lnast_ntype;
+    const auto raw     = lm->get_raw_ntype();
+
+    if (raw != Ntype::Lnast_ntype_stmts) {
+      // First child is a condition (ref or const). Try to fold it.
+      std::optional<Lconst> cval;
+      if (raw == Ntype::Lnast_ntype_const) {
+        cval = Lconst::from_pyrope(lm->current_text());
+      } else {
+        cval = try_fold_ref(lm->current_text());
+      }
+
+      if (cval && !cval->is_invalid() && !cval->has_unknowns()) {
+        const bool taken = !cval->is_known_false();
+
+        // Advance past the condition to the then-stmts.
+        if (lm->move_to_sibling()) {
+          if (taken) {
+            // Splice then-stmts children directly into the parent stmts block.
+            if (lm->has_child()) {
+              lm->move_to_child();
+              do {
+                process_lnast();
+              } while (lm->move_to_sibling());
+              lm->move_to_parent();
+            }
+            lm->move_to_parent();  // back to if-node
+            return;                // pruned — no if node emitted
+          }
+
+          // Condition is false: skip the then-stmts, look for an else-stmts.
+          if (lm->move_to_sibling()) {
+            if (lm->get_raw_ntype() == Ntype::Lnast_ntype_stmts) {
+              // Bare else-stmts: splice its children into the parent.
+              if (lm->has_child()) {
+                lm->move_to_child();
+                do {
+                  process_lnast();
+                } while (lm->move_to_sibling());
+                lm->move_to_parent();
+              }
+              lm->move_to_parent();  // back to if-node
+              return;                // pruned
+            }
+            // elif chain (next sibling is another condition, not stmts): fall
+            // through to full-if emit. Recursive elif pruning is a future task.
+          } else {
+            // No else-stmts: false condition → emit nothing.
+            lm->move_to_parent();  // back to if-node
+            return;                // pruned
+          }
+        }
+      }
+    }
+
+    lm->move_to_parent();  // condition unknown or elif chain — fall through
+  }
+
+  // Unknown condition (or elif chain): emit the full if node unchanged.
   emit_push(lm->current_node());
   if (lm->has_child()) {
     lm->move_to_child();

--- a/upass/runner/upass_runner_cycle_test.cpp
+++ b/upass/runner/upass_runner_cycle_test.cpp
@@ -90,3 +90,151 @@ TEST(UpassRunnerResolve, SharedDecideResolves) {
   EXPECT_EQ(ordered[0], "decide_shared");
   EXPECT_FALSE(runner.has_configuration_error());
 }
+
+// ── Slice 7: if-branch pruning ────────────────────────────────────────────────
+//
+// Helper: count the number of nodes of a given ntype in the staging LNAST.
+static size_t count_ntype(const Lnast& ln, Lnast_ntype::Lnast_ntype_int target) {
+  size_t n = 0;
+  for (const auto& nid : ln.depth_preorder(Lnast_nid::root())) {
+    if (ln.get_type(nid).get_raw_ntype() == target) {
+      ++n;
+    }
+  }
+  return n;
+}
+
+// Build a minimal LNAST:
+//   top → stmts → if(cond, then_stmts[assign(___a, val)], [else_stmts[assign(___a, else_val)]])
+// `cond_text` is the condition literal ("true", "false", or a ref name like "___c").
+// `else_val`  is "" when there is no else branch.
+static std::shared_ptr<Lnast> make_if_lnast(std::string_view cond_text,
+                                             std::string_view then_val  = "4",
+                                             std::string_view else_val  = "") {
+  auto ln = std::make_shared<Lnast>("if_test");
+  ln->set_root(Lnast_node::create_top());
+  auto stmts = ln->add_child(Lnast_nid::root(), Lnast_node::create_stmts());
+  auto if_nid = ln->add_child(stmts, Lnast_node::create_if());
+
+  // Condition — emit as const ("true"/"false") or ref (unknown variable).
+  bool is_literal = (cond_text == "true" || cond_text == "false");
+  if (is_literal) {
+    ln->add_child(if_nid, Lnast_node::create_const(cond_text));
+  } else {
+    ln->add_child(if_nid, Lnast_node::create_ref(cond_text));
+  }
+
+  // Then-stmts.
+  auto then_s = ln->add_child(if_nid, Lnast_node::create_stmts());
+  auto asgn1  = ln->add_child(then_s, Lnast_node::create_assign());
+  ln->add_child(asgn1, Lnast_node::create_ref("___a"));
+  ln->add_child(asgn1, Lnast_node::create_const(then_val));
+
+  // Optional else-stmts.
+  if (!else_val.empty()) {
+    auto else_s = ln->add_child(if_nid, Lnast_node::create_stmts());
+    auto asgn2  = ln->add_child(else_s, Lnast_node::create_assign());
+    ln->add_child(asgn2, Lnast_node::create_ref("___a"));
+    ln->add_child(asgn2, Lnast_node::create_const(else_val));
+  }
+
+  return ln;
+}
+
+// ── Test 1: condition is const "true" → if is pruned, then-branch spliced ───
+TEST(UpassRunnerIfPrune, TrueConditionPrunesIfNode) {
+  auto ln     = make_if_lnast("true");
+  auto lm     = std::make_shared<upass::Lnast_manager>(ln);
+  uPass_runner runner(lm, {"constprop"});
+  runner.run();
+  auto staging = runner.take_staging();
+  ASSERT_NE(staging, nullptr);
+  // No if-node should remain in the staging tree.
+  EXPECT_EQ(count_ntype(*staging, Lnast_ntype::Lnast_ntype_if), 0U);
+}
+
+// ── Test 2: condition is const "false" → if is pruned, no output emitted ────
+TEST(UpassRunnerIfPrune, FalseConditionPrunesIfNodeNoElse) {
+  auto ln     = make_if_lnast("false");
+  auto lm     = std::make_shared<upass::Lnast_manager>(ln);
+  uPass_runner runner(lm, {"constprop"});
+  runner.run();
+  auto staging = runner.take_staging();
+  ASSERT_NE(staging, nullptr);
+  // No if-node and no assign should remain (branch dropped entirely).
+  EXPECT_EQ(count_ntype(*staging, Lnast_ntype::Lnast_ntype_if), 0U);
+  EXPECT_EQ(count_ntype(*staging, Lnast_ntype::Lnast_ntype_assign), 0U);
+}
+
+// ── Test 3: condition false + else branch → else-stmts spliced into parent ──
+TEST(UpassRunnerIfPrune, FalseConditionSplicesElseBranch) {
+  auto ln     = make_if_lnast("false", "4", "5");
+  auto lm     = std::make_shared<upass::Lnast_manager>(ln);
+  uPass_runner runner(lm, {"constprop"});
+  runner.run();
+  auto staging = runner.take_staging();
+  ASSERT_NE(staging, nullptr);
+  // No if-node — else branch was spliced.
+  EXPECT_EQ(count_ntype(*staging, Lnast_ntype::Lnast_ntype_if), 0U);
+  // else branch is dropped too because ___a=5 is a known-const temp.
+  // Important invariant: staging must not crash and must have no if node.
+}
+
+// ── Test 4: unknown condition → full if node is preserved ───────────────────
+TEST(UpassRunnerIfPrune, UnknownConditionKeepsIfNode) {
+  // ___c is never defined → constprop ST has no value for it → condition unknown.
+  auto ln     = make_if_lnast("___c");
+  auto lm     = std::make_shared<upass::Lnast_manager>(ln);
+  uPass_runner runner(lm, {"constprop"});
+  runner.run();
+  auto staging = runner.take_staging();
+  ASSERT_NE(staging, nullptr);
+  // The if-node must be preserved when the condition is unknown.
+  EXPECT_GE(count_ntype(*staging, Lnast_ntype::Lnast_ntype_if), 1U);
+}
+
+// ── Test 5: ref condition resolved by constprop → if is pruned ───────────────
+// This is the primary real-world path: the condition is a tmp ref (___cond)
+// whose value is folded by constprop via a preceding eq statement.
+//
+// LNAST built:
+//   top → stmts
+//     assign:  ___x  = 3          ← known scalar
+//     eq:      ___cond = ___x == 3 ← constprop folds to true
+//     if(ref:___cond)
+//       stmts → assign: ___a = 4
+//
+// After run(): constprop sets ___cond=true in its ST; runner calls
+// try_fold_ref("___cond") → true → splices then-stmts, no if in staging.
+TEST(UpassRunnerIfPrune, RefCondResolvedByConstpropPrunesIfNode) {
+  auto ln = std::make_shared<Lnast>("if_ref_cond");
+  ln->set_root(Lnast_node::create_top());
+  auto stmts = ln->add_child(Lnast_nid::root(), Lnast_node::create_stmts());
+
+  // assign ___x = 3
+  auto asgn_x = ln->add_child(stmts, Lnast_node::create_assign());
+  ln->add_child(asgn_x, Lnast_node::create_ref("___x"));
+  ln->add_child(asgn_x, Lnast_node::create_const("3"));
+
+  // eq ___cond = ___x == 3  →  constprop folds to true (1)
+  auto eq_nid = ln->add_child(stmts, Lnast_node::create_eq());
+  ln->add_child(eq_nid, Lnast_node::create_ref("___cond"));
+  ln->add_child(eq_nid, Lnast_node::create_ref("___x"));
+  ln->add_child(eq_nid, Lnast_node::create_const("3"));
+
+  // if ___cond { assign ___a = 4 }
+  auto if_nid   = ln->add_child(stmts, Lnast_node::create_if());
+  ln->add_child(if_nid, Lnast_node::create_ref("___cond"));
+  auto then_s   = ln->add_child(if_nid, Lnast_node::create_stmts());
+  auto asgn_a   = ln->add_child(then_s, Lnast_node::create_assign());
+  ln->add_child(asgn_a, Lnast_node::create_ref("___a"));
+  ln->add_child(asgn_a, Lnast_node::create_const("4"));
+
+  auto lm     = std::make_shared<upass::Lnast_manager>(ln);
+  uPass_runner runner(lm, {"constprop"});
+  runner.run();
+  auto staging = runner.take_staging();
+  ASSERT_NE(staging, nullptr);
+  // ___cond was folded to true by constprop → runner must prune the if node.
+  EXPECT_EQ(count_ntype(*staging, Lnast_ntype::Lnast_ntype_if), 0U);
+}

--- a/upass/upass.md
+++ b/upass/upass.md
@@ -338,12 +338,18 @@ verifier / downstream consumers read via the ST.
 - Exception: tuples that cross a `func_call` boundary stay as `tup_add`
   (Slice 3 emission pattern) — they encode ABI.
 
-### Slice 7 — if-branch pruning
+### Slice 7 — if-branch pruning (landed)
 
 - If condition is comptime-known: emit only the taken branch's stmts,
-  spliced into the parent stmts block.
-- Requires phi-resolution awareness (LNAST already has SSA) so live-outs
-  of the removed branch don't leave dangling refs.
+  spliced into the parent stmts block (no `if` node in the output).
+- Implemented in `uPass_runner::process_if()`: after dispatching to passes
+  so constprop's ST is populated, the runner folds the condition via
+  `try_fold_ref`. True → splice then-stmts; false → splice else-stmts (or
+  emit nothing when there is no else); unknown → emit full if node.
+- elif chains (condition false, next sibling is another condition) are not
+  yet pruned and fall through to full-if emit. Phi-resolution concern from
+  the original stub: the current prp2lnast LNAST does not emit explicit phi
+  nodes, so live-out dangling refs are not an issue in practice.
 
 ## 4. Invariants
 

--- a/upass/upass.md
+++ b/upass/upass.md
@@ -347,9 +347,15 @@ verifier / downstream consumers read via the ST.
   `try_fold_ref`. True → splice then-stmts; false → splice else-stmts (or
   emit nothing when there is no else); unknown → emit full if node.
 - elif chains (condition false, next sibling is another condition) are not
-  yet pruned and fall through to full-if emit. Phi-resolution concern from
-  the original stub: the current prp2lnast LNAST does not emit explicit phi
-  nodes, so live-out dangling refs are not an issue in practice.
+  yet pruned and fall through to full-if emit.
+  **Known ST side-effect limitation**: `dispatch_to_passes` runs before the
+  fold decision, so constprop has already walked the entire if subtree
+  (including the statically-dead then-branch) when the elif fallthrough
+  path calls `process_lnast()` recursively.  Writes from the dead branch
+  are in constprop's ST, which could cause `classify_statement` to
+  incorrectly DCE a live write in a later elif/else body whose LHS
+  collides with a dead-branch entry.  No current test triggers this; track
+  against the test suite as elif coverage grows.
 
 ## 4. Invariants
 


### PR DESCRIPTION
## Summary

- **`upass_runner.cpp`** — `process_if()` now performs dead-branch elimination when the if-node condition is comptime-known. Dispatches to passes first (so constprop populates its ST), then folds the condition via `try_fold_ref()` (refs) or `Lconst::from_pyrope()` (literals). True → splice then-stmts into parent; false + bare else → splice else-stmts; false + no else → emit nothing; unknown / elif chain → full if node emitted unchanged.
- **`upass_runner_cycle_test.cpp`** — 5 new `UpassRunnerIfPrune` tests including the end-to-end path where constprop resolves a ref condition (`___cond = ___x == 3` with `___x = 3`) and the runner prunes the if.
- **`BUILD`** — links `//upass/constprop:upass_constprop` into `upass_runner_cycle_test` so the constprop plugin is registered at test link time.
- **`upass_constprop.cpp`** — clarified `process_if()` comment (observer role only; runner owns pruning).
- **`upass.md`** — marked Slice 7 as landed with implementation notes.

## Notes

- **elif chains** with comptime conditions fall through to full-if emit (no recursive pruning yet). Documented as a TODO; no current test cases require it.
- **prp `scope_simple` failure** is unrelated — traced to a bug in `prp2lnast.cpp::if_expr_to_node()` which always appends `result = 0` instead of the actual branch value. Not addressable by Slice 7.
- All 10 `upass_runner_cycle_test` tests pass (5 original + 5 new). No regressions vs the post-Slice-1 baseline on `master`.

## Test plan

- [ ] `bazel test //upass/runner:upass_runner_cycle_test` — all 10 pass
- [ ] `bazel test //upass/...` — all 4 upass GTest targets pass
- [ ] `bazel test //inou/prp/tests/...` — 16/22 same as master baseline (pre-existing failures, not introduced by this slice)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/masc-ucsc/livehd/532)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Compiler now automatically eliminates unreachable branches when `if` conditions are compile-time-known.

* **Tests**
  * Added comprehensive test suite for if-branch pruning behavior.

* **Documentation**
  * Updated documentation to reflect if-branch pruning implementation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->