### PR TITLE
upass/prp_writer: fix comb wrapper and mut-keyword on reassignment

### DIFF
--- a/upass/prp_writer/lnast_prp_writer.cpp
+++ b/upass/prp_writer/lnast_prp_writer.cpp
@@ -388,7 +388,9 @@ void Lnast_prp_writer::write_tuple_set() {
   if (!move_to_child()) {
     return;
   }
-  print(strip_prefix(current_text()));
+  auto lhs = strip_prefix(current_text());
+  take_decl_keyword(lhs);  // consume any pending decl so it doesn't leak
+  print(lhs);
   while (move_to_sibling() && !is_last_child()) {
     print("[");
     write_node();
@@ -467,7 +469,9 @@ void Lnast_prp_writer::write_delay_assign() {
   if (!move_to_child()) {
     return;
   }
-  print(strip_prefix(current_text()));
+  auto lhs = strip_prefix(current_text());
+  take_decl_keyword(lhs);  // consume any pending decl so it doesn't leak
+  print(lhs);
   print(" = #[");
   move_to_sibling();
   write_node();

--- a/upass/prp_writer/lnast_prp_writer.cpp
+++ b/upass/prp_writer/lnast_prp_writer.cpp
@@ -71,6 +71,16 @@ bool Lnast_prp_writer::is_tmp(std::string_view name) {
   return name.size() >= 3 && name[0] == '_' && name[1] == '_' && name[2] == '_';
 }
 
+std::string Lnast_prp_writer::take_decl_keyword(std::string_view lhs) {
+  auto it = pending_decl_.find(std::string(lhs));
+  if (it == pending_decl_.end()) {
+    return {};
+  }
+  auto kw = it->second;
+  pending_decl_.erase(it);
+  return kw;
+}
+
 std::string_view Lnast_prp_writer::strip_prefix(std::string_view name) {
   if (!name.empty() && (name[0] == '%' || name[0] == '$')) {
     return name.substr(1);
@@ -130,14 +140,12 @@ void Lnast_prp_writer::write_node() {
 // ── Structural ────────────────────────────────────────────────────────────────
 
 void Lnast_prp_writer::write_top() {
-  os << std::format("comb {}() {{\n", lnast->get_top_module_name());
-  ++depth;
+  // Bare-file modules have no enclosing comb/fun declaration in the source;
+  // explicit function definitions are emitted by write_func_def() instead.
   if (move_to_child()) {
     write_node();
     move_to_parent();
   }
-  --depth;
-  os << "}\n";
 }
 
 void Lnast_prp_writer::write_stmts() {
@@ -215,8 +223,10 @@ void Lnast_prp_writer::write_assign() {
     return;
   }
   auto lhs = strip_prefix(current_text());
-  if (!is_tmp(lhs)) {
-    print("mut ");
+  auto kw  = take_decl_keyword(lhs);
+  if (!kw.empty()) {
+    print(kw);
+    print(" ");
   }
   print(lhs);
   print(" = ");
@@ -282,8 +292,10 @@ void Lnast_prp_writer::write_func_call() {
   }
   // LHS
   auto lhs = strip_prefix(current_text());
-  if (!is_tmp(lhs)) {
-    print("mut ");
+  auto kw  = take_decl_keyword(lhs);
+  if (!kw.empty()) {
+    print(kw);
+    print(" ");
   }
   print(lhs);
   print(" = ");
@@ -331,8 +343,10 @@ void Lnast_prp_writer::write_tuple_add() {
     return;
   }
   auto lhs = strip_prefix(current_text());
-  if (!is_tmp(lhs)) {
-    print("mut ");
+  auto kw  = take_decl_keyword(lhs);
+  if (!kw.empty()) {
+    print(kw);
+    print(" ");
   }
   print(lhs);
   print(" = (");
@@ -353,8 +367,10 @@ void Lnast_prp_writer::write_tuple_get() {
     return;
   }
   auto lhs = strip_prefix(current_text());
-  if (!is_tmp(lhs)) {
-    print("mut ");
+  auto kw  = take_decl_keyword(lhs);
+  if (!kw.empty()) {
+    print(kw);
+    print(" ");
   }
   print(lhs);
   print(" = ");
@@ -397,11 +413,15 @@ void Lnast_prp_writer::write_attr_set() {
   }
 
   // Suppress LNAST-internal type annotations: attr_set x type mut/reg/wire.
-  // prp2lnast emits these before every "mut x = …" assignment.  The mut/reg
-  // keyword is already handled by write_assign / write_infix when the
-  // assignment node is present.  If the assignment was DCE'd and only the
-  // bare attr_set survives, there is nothing meaningful to emit in Pyrope.
+  // Record the storage-class keyword in pending_decl_ so the NEXT assignment
+  // to this variable can emit "mut x = …" exactly once.
   if (current_text() == "type") {
+    if (move_to_sibling()) {
+      auto kw = current_text();
+      if (kw == "mut" || kw == "reg" || kw == "wire") {
+        pending_decl_[std::string(var_name)] = std::string(kw);
+      }
+    }
     move_to_parent();
     return;
   }
@@ -425,8 +445,10 @@ void Lnast_prp_writer::write_attr_get() {
     return;
   }
   auto lhs = strip_prefix(current_text());
-  if (!is_tmp(lhs)) {
-    print("mut ");
+  auto kw  = take_decl_keyword(lhs);
+  if (!kw.empty()) {
+    print(kw);
+    print(" ");
   }
   print(lhs);
   print(" = ");
@@ -464,10 +486,12 @@ void Lnast_prp_writer::write_infix(std::string_view op) {
     return;
   }
 
-  // First child is the LHS (result variable) — read its name for mut-detection.
+  // First child is the LHS (result variable).
   auto lhs = strip_prefix(current_text());
-  if (!is_tmp(lhs)) {
-    print("mut ");
+  auto kw  = take_decl_keyword(lhs);
+  if (!kw.empty()) {
+    print(kw);
+    print(" ");
   }
   print(lhs);
   print(" = ");
@@ -492,8 +516,10 @@ void Lnast_prp_writer::write_prefix_unary(std::string_view op) {
     return;
   }
   auto lhs = strip_prefix(current_text());
-  if (!is_tmp(lhs)) {
-    print("mut ");
+  auto kw  = take_decl_keyword(lhs);
+  if (!kw.empty()) {
+    print(kw);
+    print(" ");
   }
   print(lhs);
   print(" = ");
@@ -518,8 +544,9 @@ void Lnast_prp_writer::write_sext() {
   }
   move_to_parent();
 
-  if (!is_tmp(lhs)) {
-    print("mut ");
+  auto kw = take_decl_keyword(lhs);
+  if (!kw.empty()) {
+    os << kw << " ";
   }
   os << std::format("{} = sext({}, {})  /* sign-extend */", lhs, val, bits);
 }

--- a/upass/prp_writer/lnast_prp_writer.hpp
+++ b/upass/prp_writer/lnast_prp_writer.hpp
@@ -4,7 +4,9 @@
 #include <memory>
 #include <ostream>
 #include <stack>
+#include <string>
 #include <string_view>
+#include <unordered_map>
 
 #include "lnast.hpp"
 
@@ -75,6 +77,16 @@ private:
   void write_prefix_unary(std::string_view op);
   // sext — no Pyrope operator; emit as call with comment
   void write_sext();
+
+  // ── Declaration tracking ─────────────────────────────────────────────────
+  // Maps a variable name to its pending storage-class keyword ("mut", "reg",
+  // "wire") recorded when write_attr_set() suppresses an attr_set x type kw
+  // node.  The NEXT assignment to that variable consumes the keyword (once).
+  std::unordered_map<std::string, std::string> pending_decl_;
+
+  // Returns the stored keyword for `lhs` (e.g. "mut") and removes it from
+  // the map, or returns "" if no pending declaration exists.
+  std::string take_decl_keyword(std::string_view lhs);
 
   // ── Utilities ────────────────────────────────────────────────────────────
   static bool             is_tmp(std::string_view name);

--- a/upass/prp_writer/lnast_prp_writer_test.cpp
+++ b/upass/prp_writer/lnast_prp_writer_test.cpp
@@ -96,9 +96,8 @@ TEST(LnastPrpWriter, TmpsAreDCEdByConstprop) {
 
   auto output = run_and_emit(ln, {"constprop"});
 
-  // The comb block header must appear.
-  EXPECT_NE(output.find("comb add_trivial"), std::string::npos) << output;
-  // All tmps were DCE'd — no tmp refs in output.
+  // Bare LNASTs (no func_def) have no comb wrapper — write_top() just emits
+  // the statements directly.  The key invariant is that tmp tokens are DCE'd.
   EXPECT_EQ(output.find("___"), std::string::npos) << "Tmps should be DCE'd: " << output;
 }
 
@@ -380,10 +379,10 @@ static std::string round_trip(std::string_view name, std::string_view src,
 // ── Test 13: round-trip — comb block with params is parsed as func_def ────────
 // A comb block with parameters is represented as a func_def node in LNAST.
 // func_def bodies are deferred to Slice 4, so the writer emits a TODO comment
-// in place of the body.  This test verifies:
+// in place of the body.  write_top() no longer adds a comb wrapper — that is
+// write_func_def()'s responsibility (Slice 4).  This test verifies:
 //   1. The round-trip does not crash.
-//   2. The top-level "comb rt_simple" header is emitted.
-//   3. The func_def TODO comment is present (expected current behavior).
+//   2. The func_def TODO comment is present (expected current behavior).
 TEST(LnastPrpWriter, RoundTripCombWithParamsIsFuncDef) {
   const char* src = R"prp(
 comb rt_simple(a) -> (out) {
@@ -393,7 +392,6 @@ comb rt_simple(a) -> (out) {
 
   auto output = round_trip("rt_simple", src, {"noop_shared"});
   ASSERT_FALSE(output.empty()) << "round-trip produced no output";
-  EXPECT_NE(output.find("comb rt_simple"), std::string::npos) << "comb header missing:\n" << output;
   // func_def bodies are not yet serialised (Slice 4); the writer emits a TODO.
   EXPECT_NE(output.find("TODO: func_def"), std::string::npos) << "expected func_def TODO comment:\n" << output;
 }
@@ -411,9 +409,8 @@ rt_fold()
 )prp";
 
   auto output = round_trip("rt_fold", src, {"constprop"});
-  ASSERT_FALSE(output.empty()) << "round-trip produced no output";
-  EXPECT_NE(output.find("comb rt_fold"), std::string::npos) << "comb header missing:\n" << output;
-  // After constprop, the `2 + 3` plus node should be folded — no raw `+` remains.
+  // write_top() no longer adds a comb wrapper; write_func_def() (Slice 4) will.
+  // The key invariant is that constprop folds `2 + 3` — no bare `+` survives.
   EXPECT_EQ(output.find(" + "), std::string::npos) << "unexpected `+` in output (should be folded):\n" << output;
 }
 

--- a/upass/prp_writer/lnast_prp_writer_test.cpp
+++ b/upass/prp_writer/lnast_prp_writer_test.cpp
@@ -453,6 +453,7 @@ rt_if()
 
   auto output = round_trip("rt_if", src, {"constprop"});
   ASSERT_FALSE(output.empty()) << "round-trip produced no output";
-  EXPECT_NE(output.find("comb rt_if"), std::string::npos) << "comb header missing:\n" << output;
+  // write_top() no longer adds a comb wrapper; write_func_def() (Slice 4) will.
+  // The key invariant is that constprop prunes the dead else-branch — no "if".
   EXPECT_EQ(output.find("if "), std::string::npos) << "if should be pruned but still present:\n" << output;
 }


### PR DESCRIPTION
## Summary

Two correctness bugs in `Lnast_prp_writer` fixed:

- **Remove spurious `comb NAME()` wrapper** — `write_top()` was unconditionally wrapping all output in a `comb NAME() {}` block. Bare Pyrope files have no enclosing function; the wrapper belongs in `write_func_def()` (Slice 4). `write_top()` now emits statements directly.

- **Fix `mut` on reassignments** — every assignment to a non-tmp variable was getting `mut`, so `c = 2` inside an if-block was incorrectly emitted as `mut c = 2`. `mut` (or `reg`/`wire`) must only appear at the declaration site — the assignment immediately following an `attr_set x type mut` node. `write_attr_set()` now records the pending keyword in `pending_decl_`; all LHS-emitting functions consume it once via `take_decl_keyword()`.

## Test plan

- [x] 16/16 unit tests pass (`//upass/prp_writer:upass_prp_writer_test`) on VM with clang-21
- [x] Round-trip test passes (`//pass/prp_writer:prp_writer_roundtrip_test.sh`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/masc-ucsc/livehd/539)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Improved handling of storage-class keywords in variable declarations for more consistent code generation
  * Modified output format: top-level code generation no longer wraps results in a `comb` block wrapper
  * Enhanced declaration tracking mechanism for better keyword propagation across code generation operations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->