### PR TITLE
upass/ssa: Slice 9 — SSA renaming for multi-assigned user variables

### DIFF
--- a/upass/lnast_to_lgraph/BUILD
+++ b/upass/lnast_to_lgraph/BUILD
@@ -24,6 +24,7 @@ cc_test(
     deps = [
         ":upass_lnast_to_lgraph",
         "//lgraph",
+        "//upass/ssa:upass_ssa",
         "@googletest//:gtest_main",
     ],
 )

--- a/upass/lnast_to_lgraph/lnast_to_lgraph_test.cpp
+++ b/upass/lnast_to_lgraph/lnast_to_lgraph_test.cpp
@@ -11,6 +11,7 @@
 #include "lgedgeiter.hpp"
 #include "lgraph.hpp"
 #include "lnast.hpp"
+#include "upass_ssa.hpp"
 
 namespace {
 
@@ -491,4 +492,98 @@ TEST(LnastToLgraph, FuncDefTrivialXor) {
   // No spurious Sum/Mux nodes from func_def scaffolding.
   EXPECT_EQ(count_op(lg, Ntype_op::Sum), 0);
   EXPECT_EQ(count_op(lg, Ntype_op::Mux), 0);
+}
+
+// ── Test 14: SSA renaming — multi-assigned user variable ──────────────────────
+// Verifies that uPass_ssa::run() correctly renames a variable assigned twice
+// in straight-line code, and that the resulting LNAST lowers cleanly to LGraph.
+//
+// Source (conceptual Pyrope):
+//   comb f(a:u4, b:u4) -> (c:u4) {
+//     t = a + b      // first assignment
+//     t = t + 1      // second assignment → renamed t___ssa_1 after SSA
+//     c = t          // reads t___ssa_1
+//   }
+//
+// Expected LGraph: 2 Sum nodes (one per addition), inputs a & b, output c.
+// The SSA rename ensures the second plus uses the result of the first, not
+// a fresh graph input.
+TEST(LnastToLgraph, SsaRenameMultiAssign) {
+  // Build post-func_extract LNAST:
+  //   top → io(ref __input_tuple_ref, ref __output_tuple_ref)
+  //        → stmts(
+  //            tuple_add(__input_tuple_ref){ assign(a,nil), assign(b,nil) }
+  //            tuple_add(__output_tuple_ref){ assign(c,nil) }
+  //            plus(t, a, b)         // t = a + b
+  //            plus(t, t, 1)         // t = t + 1  (multi-assign → gets renamed)
+  //            assign(c, t)          // c = t      (reads renamed t)
+  //          )
+  auto ln   = std::make_shared<Lnast>("ssa_multiassign");
+  auto root = ln->set_root(Lnast_ntype::create_top());
+
+  auto io = ln->add_child(root, Lnast_ntype::create_io());
+  ln->add_child(io, Lnast_node::create_ref("__input_tuple_ref"));
+  ln->add_child(io, Lnast_node::create_ref("__output_tuple_ref"));
+
+  auto stmts = ln->add_child(root, Lnast_ntype::create_stmts());
+
+  // Inputs tuple_add
+  auto in_ta = ln->add_child(stmts, Lnast_ntype::create_tuple_add());
+  ln->add_child(in_ta, Lnast_node::create_ref("__input_tuple_ref"));
+  auto ai_a = ln->add_child(in_ta, Lnast_ntype::create_assign());
+  ln->add_child(ai_a, Lnast_node::create_ref("a"));
+  ln->add_child(ai_a, Lnast_node::create_const("nil"));
+  auto ai_b = ln->add_child(in_ta, Lnast_ntype::create_assign());
+  ln->add_child(ai_b, Lnast_node::create_ref("b"));
+  ln->add_child(ai_b, Lnast_node::create_const("nil"));
+
+  // Outputs tuple_add
+  auto out_ta = ln->add_child(stmts, Lnast_ntype::create_tuple_add());
+  ln->add_child(out_ta, Lnast_node::create_ref("__output_tuple_ref"));
+  auto ao_c = ln->add_child(out_ta, Lnast_ntype::create_assign());
+  ln->add_child(ao_c, Lnast_node::create_ref("c"));
+  ln->add_child(ao_c, Lnast_node::create_const("nil"));
+
+  // plus(t, a, b)  →  t = a + b
+  auto p1 = ln->add_child(stmts, Lnast_ntype::create_plus());
+  ln->add_child(p1, Lnast_node::create_ref("t"));
+  ln->add_child(p1, Lnast_node::create_ref("a"));
+  ln->add_child(p1, Lnast_node::create_ref("b"));
+
+  // plus(t, t, 1)  →  t = t + 1  (second assignment to t — SSA renames this)
+  auto p2 = ln->add_child(stmts, Lnast_ntype::create_plus());
+  ln->add_child(p2, Lnast_node::create_ref("t"));
+  ln->add_child(p2, Lnast_node::create_ref("t"));
+  ln->add_child(p2, Lnast_node::create_const("1"));
+
+  // assign(c, t)   →  c = t  (reads the SSA-renamed version of t)
+  auto asgn = ln->add_child(stmts, Lnast_ntype::create_assign());
+  ln->add_child(asgn, Lnast_node::create_ref("c"));
+  ln->add_child(asgn, Lnast_node::create_ref("t"));
+
+  // Run the SSA pass: should rename the second `t` to `t___ssa_1` and
+  // substitute the RHS `t` in the third statement with `t___ssa_1`.
+  uPass_ssa::run(ln);
+
+  // Verify io_meta was harvested correctly.
+  ASSERT_EQ(ln->io_meta().inputs.size(), 2u);
+  EXPECT_EQ(ln->io_meta().inputs[0].name, "a");
+  EXPECT_EQ(ln->io_meta().inputs[1].name, "b");
+  ASSERT_EQ(ln->io_meta().outputs.size(), 1u);
+  EXPECT_EQ(ln->io_meta().outputs[0].name, "c");
+
+  // Lower to LGraph via the io_meta path.
+  auto* lg = make_lg("ssa_multiassign14");
+  ASSERT_NE(lg, nullptr);
+  Lnast_to_lgraph lowerer(lg, ln);
+  lowerer.lower();
+
+  // Expect exactly 2 Sum nodes (one for a+b, one for t+1).
+  EXPECT_EQ(count_op(lg, Ntype_op::Sum), 2) << "expected two Sum nodes";
+  EXPECT_TRUE(has_input(lg, "a"))            << "expected graph input 'a'";
+  EXPECT_TRUE(has_input(lg, "b"))            << "expected graph input 'b'";
+  EXPECT_TRUE(has_output(lg, "c"))           << "expected graph output 'c'";
+  // No Mux or Xor nodes expected.
+  EXPECT_EQ(count_op(lg, Ntype_op::Mux), 0);
+  EXPECT_EQ(count_op(lg, Ntype_op::Xor), 0);
 }

--- a/upass/ssa/upass_ssa.cpp
+++ b/upass/ssa/upass_ssa.cpp
@@ -171,6 +171,12 @@ void uPass_ssa::run(const std::shared_ptr<Lnast>& lnast) {
     if (stmt_has_dest(type)) {
       auto stmt_node = staging->add_child(new_stmts, type);
 
+      // Defer rename_map update until after RHS is fully copied so that a
+      // self-referencing assignment like `t = t + 1` (second assignment)
+      // reads the *previous* SSA version of `t` on the RHS, not the new one.
+      std::string pending_lhs;  // empty = no deferred update
+      std::string pending_ssa;
+
       bool first = true;
       for (auto sub : lnast->children(child)) {
         if (first) {
@@ -180,10 +186,11 @@ void uPass_ssa::run(const std::shared_ptr<Lnast>& lnast) {
 
           if (is_user_var(lhs_name)) {
             if (seen_lhs.count(lhs_name)) {
-              // Second (or later) assignment → fresh SSA version.
-              int n    = ++ssa_count[lhs_name];
+              // Preview next SSA version — do NOT touch rename_map yet.
+              int n    = ssa_count[lhs_name] + 1;
               out_name = lhs_name + "___ssa_" + std::to_string(n);
-              rename_map[lhs_name] = out_name;
+              pending_lhs = lhs_name;
+              pending_ssa = out_name;
             } else {
               seen_lhs.insert(lhs_name);
               // Initialise identity mapping so RHS reads work correctly
@@ -196,9 +203,15 @@ void uPass_ssa::run(const std::shared_ptr<Lnast>& lnast) {
           staging->add_child(stmt_node, Lnast_node::create_ref(out_name));
           first = false;
         } else {
-          // ── RHS: substitute renamed refs ───────────────────────────────
+          // ── RHS: rename_map still holds OLD mapping — correct. ──────────
           copy_with_rename(lnast, sub, staging, stmt_node, rename_map);
         }
+      }
+
+      // Apply deferred update: subsequent statements now see the new SSA name.
+      if (!pending_lhs.empty()) {
+        ++ssa_count[pending_lhs];
+        rename_map[pending_lhs] = pending_ssa;
       }
     } else {
       // Control-flow / structural nodes (if, func_def, …): copy verbatim.

--- a/upass/ssa/upass_ssa.cpp
+++ b/upass/ssa/upass_ssa.cpp
@@ -4,11 +4,33 @@
 
 #include <format>
 #include <string>
+#include <unordered_map>
+#include <unordered_set>
 
 #include "lnast_ntype.hpp"
 
 namespace {
 constexpr std::string_view k_empty_tuple = "__empty_tuple";
+
+// Returns true for LNAST statement types whose first child is the write
+// destination (LHS) and whose remaining children are read operands (RHS).
+// This range covers: assign, dp_assign, delay_assign, all arithmetic/logic/
+// comparison/shift/bit-manipulation ops up to `ge` inclusive.
+// Excluded: if, for, while, func_*, stmts, io, top, ref, const, tuple_*,
+// attr_*, cassert, type_*, and all type-leaf nodes.
+constexpr bool stmt_has_dest(Lnast_ntype::Lnast_ntype_int t) {
+  return t >= Lnast_ntype::Lnast_ntype_assign && t <= Lnast_ntype::Lnast_ntype_ge;
+}
+}  // namespace
+
+// ── is_user_var ──────────────────────────────────────────────────────────────
+bool uPass_ssa::is_user_var(std::string_view name) {
+  if (name.empty()) return false;
+  // Port sigils — pinned to graph I/O, never rename.
+  if (name[0] == '$' || name[0] == '%') return false;
+  // Compiler-generated temporaries — already unique per func_extract.
+  if (name.size() >= 3 && name[0] == '_' && name[1] == '_' && name[2] == '_') return false;
+  return true;
 }
 
 // ── copy_subtree ─────────────────────────────────────────────────────────────
@@ -16,7 +38,7 @@ void uPass_ssa::copy_subtree(const std::shared_ptr<Lnast>& src,
                               const Lnast_nid&               src_nid,
                               const std::shared_ptr<Lnast>& dst,
                               const Lnast_nid&               dst_parent) {
-  auto     type    = src->get_type(src_nid);
+  auto      type    = src->get_type(src_nid);
   Lnast_nid new_nid;
   if (Lnast_ntype::is_ref(type)) {
     new_nid = dst->add_child(dst_parent, Lnast_node::create_ref(src->get_name(src_nid)));
@@ -29,6 +51,32 @@ void uPass_ssa::copy_subtree(const std::shared_ptr<Lnast>& src,
   }
   for (auto child : src->children(src_nid)) {
     copy_subtree(src, child, dst, new_nid);
+  }
+}
+
+// ── copy_with_rename ─────────────────────────────────────────────────────────
+void uPass_ssa::copy_with_rename(
+    const std::shared_ptr<Lnast>&                       src,
+    const Lnast_nid&                                    src_nid,
+    const std::shared_ptr<Lnast>&                       dst,
+    const Lnast_nid&                                    dst_parent,
+    const std::unordered_map<std::string, std::string>& rename_map) {
+  auto      type    = src->get_type(src_nid);
+  Lnast_nid new_nid;
+  if (Lnast_ntype::is_ref(type)) {
+    auto        name = std::string(src->get_name(src_nid));
+    auto        it   = rename_map.find(name);
+    const auto& out  = (it != rename_map.end()) ? it->second : name;
+    new_nid = dst->add_child(dst_parent, Lnast_node::create_ref(out));
+  } else if (Lnast_ntype::is_const(type)) {
+    new_nid = dst->add_child(dst_parent, Lnast_node::create_const(src->get_name(src_nid)));
+  } else if (Lnast_ntype::is_invalid(type)) {
+    new_nid = dst->add_child(dst_parent, Lnast_node::create_invalid());
+  } else {
+    new_nid = dst->add_child(dst_parent, type);
+  }
+  for (auto child : src->children(src_nid)) {
+    copy_with_rename(src, child, dst, new_nid, rename_map);
   }
 }
 
@@ -71,20 +119,16 @@ void uPass_ssa::run(const std::shared_ptr<Lnast>& lnast) {
   for (auto child : lnast->children(stmts_nid)) {
     if (!Lnast_ntype::is_tuple_add(lnast->get_type(child))) continue;
 
-    // First child of tuple_add is the ref to the tuple name.
     Lnast_nid first_ch = lnast->get_first_child(child);
     if (first_ch.is_invalid()) continue;
     auto tuple_ref = std::string(lnast->get_name(first_ch));
 
-    const bool is_input  = !input_ref_name.empty()
-                           && tuple_ref == input_ref_name
+    const bool is_input  = !input_ref_name.empty() && tuple_ref == input_ref_name
                            && tuple_ref != k_empty_tuple;
-    const bool is_output = !output_ref_name.empty()
-                           && tuple_ref == output_ref_name
+    const bool is_output = !output_ref_name.empty() && tuple_ref == output_ref_name
                            && tuple_ref != k_empty_tuple;
     if (!is_input && !is_output) continue;
 
-    // Each remaining assign child carries one field name.
     for (auto field_node : lnast->children(child)) {
       if (!Lnast_ntype::is_assign(lnast->get_type(field_node))) continue;
       Lnast_nid lhs = lnast->get_first_child(field_node);
@@ -95,31 +139,73 @@ void uPass_ssa::run(const std::shared_ptr<Lnast>& lnast) {
     }
   }
 
-  // ── Build staging tree: top → stmts (body only, no io / tuple_add I/O) ───
+  // ── Build staging tree with SSA renaming ─────────────────────────────────
   auto staging_body = lnast->forest()->create_tree_temp(
       std::format("ssa-{}", lnast->get_top_module_name()));
   auto staging   = std::make_shared<Lnast>(staging_body, lnast->get_top_module_name());
   auto new_root  = staging->set_root(Lnast_ntype::create_top());
   auto new_stmts = staging->add_child(new_root, Lnast_ntype::create_stmts());
 
-  // Copy body statements, skipping only the tuple_add nodes that target
-  // the harvested I/O tuple refs.  Body-local tuple_adds (local struct ops)
-  // must be preserved so downstream passes / the lowerer can see them.
+  // SSA rename state (straight-line scope only; branches copied verbatim).
+  std::unordered_map<std::string, std::string> rename_map;   // base → current SSA name
+  std::unordered_map<std::string, int>         ssa_count;    // version counter
+  std::unordered_set<std::string>              seen_lhs;     // first-seen tracker
+
   for (auto child : lnast->children(stmts_nid)) {
-    if (Lnast_ntype::is_tuple_add(lnast->get_type(child))) {
+    auto type = lnast->get_type(child);
+
+    // ── Skip I/O tuple_adds (harvested above) ──────────────────────────────
+    if (Lnast_ntype::is_tuple_add(type)) {
       Lnast_nid first_ch = lnast->get_first_child(child);
       if (!first_ch.is_invalid()) {
-        auto       tuple_ref = std::string(lnast->get_name(first_ch));
-        const bool is_io_input
-            = !input_ref_name.empty() && tuple_ref == input_ref_name && tuple_ref != k_empty_tuple;
-        const bool is_io_output
-            = !output_ref_name.empty() && tuple_ref == output_ref_name && tuple_ref != k_empty_tuple;
-        if (is_io_input || is_io_output) {
-          continue;  // I/O tuple_add — already harvested into io_meta_.
-        }
+        auto       tuple_ref  = std::string(lnast->get_name(first_ch));
+        const bool is_io_inp  = !input_ref_name.empty()  && tuple_ref == input_ref_name
+                                && tuple_ref != k_empty_tuple;
+        const bool is_io_out  = !output_ref_name.empty() && tuple_ref == output_ref_name
+                                && tuple_ref != k_empty_tuple;
+        if (is_io_inp || is_io_out) continue;
       }
     }
-    copy_subtree(lnast, child, staging, new_stmts);
+
+    // ── Statements with a write dest as first child: apply SSA renaming ────
+    if (stmt_has_dest(type)) {
+      auto stmt_node = staging->add_child(new_stmts, type);
+
+      bool first = true;
+      for (auto sub : lnast->children(child)) {
+        if (first) {
+          // ── LHS ────────────────────────────────────────────────────────
+          auto lhs_name = std::string(lnast->get_name(sub));
+          std::string out_name = lhs_name;
+
+          if (is_user_var(lhs_name)) {
+            if (seen_lhs.count(lhs_name)) {
+              // Second (or later) assignment → fresh SSA version.
+              int n    = ++ssa_count[lhs_name];
+              out_name = lhs_name + "___ssa_" + std::to_string(n);
+              rename_map[lhs_name] = out_name;
+            } else {
+              seen_lhs.insert(lhs_name);
+              // Initialise identity mapping so RHS reads work correctly
+              // even before a rename is needed.
+              if (rename_map.find(lhs_name) == rename_map.end()) {
+                rename_map[lhs_name] = lhs_name;
+              }
+            }
+          }
+          staging->add_child(stmt_node, Lnast_node::create_ref(out_name));
+          first = false;
+        } else {
+          // ── RHS: substitute renamed refs ───────────────────────────────
+          copy_with_rename(lnast, sub, staging, stmt_node, rename_map);
+        }
+      }
+    } else {
+      // Control-flow / structural nodes (if, func_def, …): copy verbatim.
+      // The lowerer's lower_branch() + Mux logic handles if/else correctly
+      // without LNAST-level join nodes.
+      copy_subtree(lnast, child, staging, new_stmts);
+    }
   }
 
   // Commit: replace the original LNAST body with the staging tree.

--- a/upass/ssa/upass_ssa.hpp
+++ b/upass/ssa/upass_ssa.hpp
@@ -2,6 +2,9 @@
 #pragma once
 
 #include <memory>
+#include <string>
+#include <string_view>
+#include <unordered_map>
 
 #include "lnast.hpp"
 
@@ -20,21 +23,41 @@
 // If the LNAST does NOT have the post-func_extract layout (e.g. a top-level
 // module with no 'io' child), run() is a no-op.
 //
-// SSA renaming for user variables assigned more than once is a planned
-// extension (documented in upass/upass.md §Slice 8 / §Slice 9).
+// Slice 9: SSA renaming for straight-line code.
+// Multi-assigned user variables (`x = …; x = …`) are renamed to SSA-unique
+// names (`x`, `x___ssa_1`, …). Compiler-generated temporaries (prefix `___`)
+// and port sigils (`$`, `%`) are skipped — they are already unique.
+//
+// If/else branch bodies are copied verbatim (no SSA inside branches).
+// Post-branch join merging is left to lnast_to_lgraph's lower_branch()/Mux
+// logic, which already handles it correctly.  Loop phi-nodes are out of
+// scope for this first implementation.
 class uPass_ssa {
 public:
   // Run the pass on `lnast` in-place.  After this call:
   //   - lnast->io_meta() is populated (if the LNAST had the func_extract shape)
   //   - lnast's tree body is the SSA-normalised form (io+tuple_add I/O replaced
-  //     by flat stmts with the body only)
+  //     by flat stmts with the body only, multi-assigned user vars renamed)
   static void run(const std::shared_ptr<Lnast>& lnast);
 
 private:
   // Recursively copy the subtree rooted at src_nid from src into dst,
-  // appending it as a child of dst_parent.
+  // appending it as a child of dst_parent.  No renaming applied.
   static void copy_subtree(const std::shared_ptr<Lnast>& src,
                             const Lnast_nid&               src_nid,
                             const std::shared_ptr<Lnast>& dst,
                             const Lnast_nid&               dst_parent);
+
+  // Recursively copy src_nid into dst under dst_parent, substituting any
+  // ref whose base name appears in rename_map with its current SSA name.
+  static void copy_with_rename(
+      const std::shared_ptr<Lnast>&                       src,
+      const Lnast_nid&                                    src_nid,
+      const std::shared_ptr<Lnast>&                       dst,
+      const Lnast_nid&                                    dst_parent,
+      const std::unordered_map<std::string, std::string>& rename_map);
+
+  // Returns true when `name` is a user variable that should participate in
+  // SSA renaming (excludes compiler temps `___*` and port sigils `$`/`%`).
+  static bool is_user_var(std::string_view name);
 };


### PR DESCRIPTION
## Summary

Implements the SSA renaming step (Slice 9 of `upass/upass.md`) inside `uPass_ssa::run()`. User variables assigned more than once in straight-line code are renamed to SSA-unique names (`x`, `x___ssa_1`, …), and all subsequent RHS references of the original name are substituted with the current version.

Depends on #544 (I/O harvest + tuple expansion) — both now in upstream master.

## What changed

- **`upass/ssa/upass_ssa.cpp`** — the staging-tree copy loop now distinguishes:
  - *Statements with a write dest as first child* (`assign` through `ge` in the enum): LHS tracked in `seen_lhs`; on second assignment generates `name___ssa_N` and updates `rename_map`. RHS children copied through `copy_with_rename()` which substitutes any ref in `rename_map`.
  - *Control-flow / structural nodes* (`if`, `func_def`, …): copied verbatim via `copy_subtree()`. Post-branch join is handled by the lowerer's existing `lower_branch()` + Mux logic.
- **`upass/ssa/upass_ssa.hpp`** — declares `copy_with_rename()` and `is_user_var()`.
- **Exclusions**: compiler-generated temporaries (`___` prefix) and port sigils (`$`, `%`) are skipped — they are already unique.
- **`upass/lnast_to_lgraph/lnast_to_lgraph_test.cpp`** — Test 14 (`SsaRenameMultiAssign`): builds post-func_extract LNAST for `t = a+b; t = t+1; c = t`, runs `uPass_ssa::run()`, verifies `io_meta_` harvesting, then lowers to LGraph and checks for exactly 2 Sum nodes with inputs `a`, `b` and output `c`.

## What's not in scope (documented in header)

- If/else join-point merging in the LNAST (post-branch SSA phi-nodes) — the lowerer's `lower_branch()` handles it correctly without LNAST-level join nodes.
- Loop phi-nodes — deferred pending direction from Prof. Renau.

## Test plan

- [x] `bazel test //upass/lnast_to_lgraph:upass_lnast_to_lgraph_test` — **14/14 pass**
- [x] `bazel build //pass/upass:pass_upass` — clean
- [x] `equiv_test.sh trivial` with `ssa:1 attributes:1` — `Equivalence successfully proven!`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/masc-ucsc/livehd/545)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced SSA variable renaming to properly handle variables with multiple assignments.

* **Tests**
  * Added test case validating SSA renaming behavior with multiple variable assignments.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/masc-ucsc/livehd/pull/545)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->