### PR TITLE
upass/bitwidth: wire into default pipeline + attr_set narrowing

### DIFF
--- a/lnast/lnast.hpp
+++ b/lnast/lnast.hpp
@@ -9,6 +9,7 @@
 #include <stdexcept>
 #include <string>
 #include <string_view>
+#include <unordered_map>
 
 #include "absl/container/flat_hash_map.h"
 #include "absl/strings/str_cat.h"
@@ -71,6 +72,25 @@ private:
   std::string text;
 };
 
+// ── Bitwidth metadata side-channel (populated by upass/bitwidth) ─────────────
+// A lightweight POD mirror of Lnast_range stored on the Lnast after the
+// bitwidth pass runs.  lnast_range.hpp is intentionally NOT included here to
+// avoid a dependency between lnast/ and upass/bitwidth/.
+struct BitwidthEntry {
+  int64_t min{0};
+  int64_t max{0};
+  bool    neg_inf{true};  // min = −∞ (unbounded below)
+  bool    pos_inf{true};  // max = +∞ (unbounded above)
+
+  bool is_unbounded() const noexcept { return neg_inf || pos_inf; }
+  bool is_constant()  const noexcept { return !neg_inf && !pos_inf && min == max; }
+};
+
+struct Lnast_bitwidth_meta {
+  std::unordered_map<std::string, BitwidthEntry> ranges;
+  bool empty() const noexcept { return ranges.empty(); }
+};
+
 // ── I/O metadata side-channel (populated by upass/ssa when ssa:1 is set) ────
 // Separate from hhds::TreeIO (which is tree-replacement plumbing).
 struct Lnast_io_entry {
@@ -98,6 +118,9 @@ private:
   // I/O metadata populated by the SSA upass (ssa:1).  Empty unless the SSA
   // pass has run on this LNAST.
   Lnast_tree_io                 io_meta_;
+  // Bitwidth metadata populated by uPass_bitwidth::end_run().  Empty unless
+  // the bitwidth pass has run on this LNAST.
+  Lnast_bitwidth_meta           bw_meta_;
 
 public:
   static constexpr char version[] = "0.1.0";
@@ -199,6 +222,10 @@ public:
   // ── I/O metadata side-channel (set by the SSA upass when ssa:1) ─────────
   const Lnast_tree_io& io_meta() const noexcept { return io_meta_; }
   Lnast_tree_io&       io_meta() noexcept { return io_meta_; }
+
+  // ── Bitwidth metadata side-channel (set by uPass_bitwidth::end_run) ──────
+  const Lnast_bitwidth_meta& bw_meta() const noexcept { return bw_meta_; }
+  Lnast_bitwidth_meta&       bw_meta() noexcept { return bw_meta_; }
 
   // ── name predicates (work off the textual name only) ────────────────────
   static bool is_register(std::string_view name) { return !name.empty() && name.front() == '#'; }

--- a/pass/upass/BUILD
+++ b/pass/upass/BUILD
@@ -18,6 +18,7 @@ cc_library(
         "//pass/common:pass",
         "//upass/assert:upass_assert",
         "//upass/attributes:upass_attributes",
+        "//upass/bitwidth:upass_bitwidth",
         "//upass/coalescer:upass_coalescer",
         "//upass/constprop:upass_constprop",
         "//upass/core:upass",

--- a/pass/upass/pass_upass.cpp
+++ b/pass/upass/pass_upass.cpp
@@ -14,6 +14,7 @@
 #include <vector>
 
 #include "upass_attributes.hpp"  // NOLINT: ensures plugin "attributes" is linked
+#include "upass_bitwidth.hpp"    // NOLINT: ensures plugin "bitwidth" is linked
 #include "upass_constprop.hpp"
 #include "upass_runner.hpp"
 #include "upass_ssa.hpp"
@@ -75,6 +76,9 @@ void Pass_upass::setup() {
   m1.add_label_optional("constprop", "enable constant propagation upass", "true");
   m1.add_label_optional("coalescer", "enable deferred-emit / DSE coalescer upass", "true");
   m1.add_label_optional("attributes", "enable Pyrope attribute upass (sticky propagation, comptime checks)", "true");
+  m1.add_label_optional("bitwidth",
+                        "enable LNAST bitwidth optimizer (range inference; publishes max/min into bw_meta)",
+                        "true");
   m1.add_label_optional("ssa",
                         "enable SSA normalisation: harvest I/O metadata into tree_io, expand I/O tuple nodes, "
                         "rename multi-assigned user variables to SSA-unique names",
@@ -174,6 +178,9 @@ Pass_upass::Pass_upass(const Eprp_var& var) : Pass("pass.upass", var) {
   auto attrs_txt   = get_label("attributes");
   bool do_attrs    = attrs_txt != "false" && attrs_txt != "0";
 
+  auto bw_txt      = get_label("bitwidth");
+  bool do_bitwidth = bw_txt != "false" && bw_txt != "0";
+
   auto ssa_txt = get_label("ssa");
   bool do_ssa  = ssa_txt != "false" && ssa_txt != "0";
   run_ssa      = do_ssa;
@@ -202,6 +209,13 @@ Pass_upass::Pass_upass(const Eprp_var& var) : Pass("pass.upass", var) {
   // they share the same `attributes` plugin and are toggled internally.
   if (do_attrs) {
     upass_order.emplace_back("attributes");
+  }
+
+  // Bitwidth runs after attributes (so wrap/saturate policy is on the
+  // symbol table) and before constprop (so `.[max]`/`.[min]`/`.[bits]`
+  // reads can fold using the inferred ranges).
+  if (do_bitwidth) {
+    upass_order.emplace_back("bitwidth");
   }
 
   if (do_constprop) {

--- a/upass/bitwidth/BUILD
+++ b/upass/bitwidth/BUILD
@@ -16,6 +16,7 @@ cc_library(
     deps = [
         "//core",
         "//lnast",
+        "//pass/common:pass",
         "//upass/core:upass",
     ],
     alwayslink = True,  # ensures the static plugin_bitwidth registration fires

--- a/upass/bitwidth/BUILD
+++ b/upass/bitwidth/BUILD
@@ -1,0 +1,36 @@
+# This file is distributed under the BSD 3-Clause License. See LICENSE for details.
+# buildifier: disable=load
+load("@rules_cc//cc:defs.bzl", "cc_library", "cc_test")
+load("//tools:copt_default.bzl", "COPTS")
+
+cc_library(
+    name = "upass_bitwidth",
+    srcs = ["upass_bitwidth.cpp"],
+    hdrs = [
+        "lnast_range.hpp",
+        "upass_bitwidth.hpp",
+    ],
+    copts = COPTS,
+    includes = ["."],
+    visibility = ["//visibility:public"],
+    deps = [
+        "//core",
+        "//lnast",
+        "//upass/core:upass",
+    ],
+    alwayslink = True,  # ensures the static plugin_bitwidth registration fires
+)
+
+cc_test(
+    name = "upass_bitwidth_test",
+    srcs = ["upass_bitwidth_test.cpp"],
+    copts = COPTS,
+    deps = [
+        ":upass_bitwidth",
+        "//core",
+        "//lnast",
+        "//upass/core:upass",
+        "//upass/runner:upass_runner",
+        "@googletest//:gtest_main",
+    ],
+)

--- a/upass/bitwidth/lnast_range.hpp
+++ b/upass/bitwidth/lnast_range.hpp
@@ -1,6 +1,7 @@
 //  This file is distributed under the BSD 3-Clause License. See LICENSE for details.
 #pragma once
 
+#include <algorithm>
 #include <bit>
 #include <cstdint>
 #include <limits>

--- a/upass/bitwidth/lnast_range.hpp
+++ b/upass/bitwidth/lnast_range.hpp
@@ -1,0 +1,222 @@
+//  This file is distributed under the BSD 3-Clause License. See LICENSE for details.
+#pragma once
+
+#include <bit>
+#include <cstdint>
+#include <limits>
+
+// ── Lnast_range — simple signed min/max range lattice ────────────────────────
+//
+// A range with explicit ±∞ flags instead of overflow sentinels.  The two
+// invariants are:
+//   1. When both neg_inf and pos_inf are false: min <= max.
+//   2. When neg_inf is true the `min` field is ignored.
+//      When pos_inf is true the `max` field is ignored.
+//
+// All arithmetic methods return unbounded() conservatively on int64_t overflow.
+// Boolean / comparison results use the signed-1-bit lattice point {-1, 0}.
+struct Lnast_range {
+  int64_t min{0};
+  int64_t max{0};
+  bool    neg_inf{true};  // min = -∞
+  bool    pos_inf{true};  // max = +∞
+
+  // ── Constructors / named factories ────────────────────────────────────────
+
+  static constexpr Lnast_range unbounded() noexcept {
+    Lnast_range r;
+    r.neg_inf = true;
+    r.pos_inf = true;
+    return r;
+  }
+
+  static constexpr Lnast_range constant(int64_t v) noexcept {
+    Lnast_range r;
+    r.min     = v;
+    r.max     = v;
+    r.neg_inf = false;
+    r.pos_inf = false;
+    return r;
+  }
+
+  // Signed 1-bit: range [-1, 0].  Used for boolean and comparison results.
+  static constexpr Lnast_range boolean() noexcept {
+    Lnast_range r;
+    r.min     = -1;
+    r.max     = 0;
+    r.neg_inf = false;
+    r.pos_inf = false;
+    return r;
+  }
+
+  // ── Predicates ────────────────────────────────────────────────────────────
+
+  bool is_constant() const noexcept { return !neg_inf && !pos_inf && min == max; }
+  bool is_unbounded() const noexcept { return neg_inf || pos_inf; }
+
+  // True when this range covers a strictly smaller set of values than `other`.
+  // An unbounded side is never narrower than anything (so we return false).
+  bool is_narrower_than(const Lnast_range& other) const noexcept {
+    if (is_unbounded()) return false;
+    if (other.is_unbounded()) return true;
+    return min > other.min || max < other.max;
+  }
+
+  // True iff all representable values are ≥ 0.
+  bool is_always_positive() const noexcept { return !neg_inf && min >= 0; }
+  // True iff all representable values are < 0.
+  bool is_always_negative() const noexcept { return !pos_inf && max < 0; }
+  // True when the range spans negative values (i.e. two's complement signed).
+  bool is_signed() const noexcept { return neg_inf || min < 0; }
+
+  // ── Signed bit-width ──────────────────────────────────────────────────────
+  // Returns the minimum number of bits needed to represent [min, max] in two's
+  // complement. Returns 64 (a conservative upper bound) for unbounded ranges.
+  int64_t get_sbits() const noexcept {
+    if (neg_inf || pos_inf) return 64;
+    return std::max(sbits_for(min), sbits_for(max));
+  }
+
+  // ── Lattice operations ────────────────────────────────────────────────────
+
+  // join: widest range covering both — used for if/else mux join.
+  Lnast_range join(const Lnast_range& b) const noexcept {
+    if (neg_inf || pos_inf || b.neg_inf || b.pos_inf) {
+      // If either side is totally unbounded return unbounded.
+      Lnast_range r;
+      r.neg_inf = neg_inf   || b.neg_inf;
+      r.pos_inf = pos_inf   || b.pos_inf;
+      if (!r.neg_inf) r.min = std::min(min, b.min);
+      if (!r.pos_inf) r.max = std::max(max, b.max);
+      return r;
+    }
+    Lnast_range r;
+    r.min     = std::min(min, b.min);
+    r.max     = std::max(max, b.max);
+    r.neg_inf = false;
+    r.pos_inf = false;
+    return r;
+  }
+
+  // meet: intersection — used for explicit constraints.
+  // If the intersection is empty, returns unbounded (conservative fallback).
+  Lnast_range meet(const Lnast_range& b) const noexcept {
+    if (neg_inf || pos_inf) return b;  // [−∞,+∞] ∩ b = b
+    if (b.neg_inf || b.pos_inf) return *this;
+    int64_t lo = std::max(min, b.min);
+    int64_t hi = std::min(max, b.max);
+    if (lo > hi) return unbounded();  // empty intersection → conservative
+    Lnast_range r;
+    r.min     = lo;
+    r.max     = hi;
+    r.neg_inf = false;
+    r.pos_inf = false;
+    return r;
+  }
+
+  // ── Arithmetic ────────────────────────────────────────────────────────────
+
+  Lnast_range add(const Lnast_range& b) const noexcept {
+    if (is_unbounded() || b.is_unbounded()) return unbounded();
+    int64_t lo, hi;
+    if (add_overflow(min, b.min, lo) || add_overflow(max, b.max, hi)) return unbounded();
+    return bounded(lo, hi);
+  }
+
+  Lnast_range sub(const Lnast_range& b) const noexcept {
+    if (is_unbounded() || b.is_unbounded()) return unbounded();
+    // [a.min - b.max, a.max - b.min]
+    int64_t lo, hi;
+    if (sub_overflow(min, b.max, lo) || sub_overflow(max, b.min, hi)) return unbounded();
+    return bounded(lo, hi);
+  }
+
+  Lnast_range mul(const Lnast_range& b) const noexcept {
+    if (is_unbounded() || b.is_unbounded()) return unbounded();
+    // All four corner products.
+    using i128 = __int128;
+    i128 c0 = (i128)min * b.min;
+    i128 c1 = (i128)min * b.max;
+    i128 c2 = (i128)max * b.min;
+    i128 c3 = (i128)max * b.max;
+    i128 lo = std::min({c0, c1, c2, c3});
+    i128 hi = std::max({c0, c1, c2, c3});
+    constexpr i128 kMin = (i128)std::numeric_limits<int64_t>::min();
+    constexpr i128 kMax = (i128)std::numeric_limits<int64_t>::max();
+    if (lo < kMin || hi > kMax) return unbounded();
+    return bounded((int64_t)lo, (int64_t)hi);
+  }
+
+  Lnast_range neg() const noexcept {
+    if (is_unbounded()) return unbounded();
+    // Check INT64_MIN negation overflow.
+    if (min == std::numeric_limits<int64_t>::min()) return unbounded();
+    return bounded(-max, -min);
+  }
+
+  // Logical shift left: result = [min << b_lo, max << b_hi].
+  // Conservative: returns unbounded when b is not bounded-positive.
+  Lnast_range shl(const Lnast_range& amt) const noexcept {
+    if (is_unbounded()) return unbounded();
+    if (amt.is_unbounded() || amt.min < 0) return unbounded();
+    if (amt.min > 62 || amt.max > 62) return unbounded();
+    using i128 = __int128;
+    i128 lo = (i128)min << amt.min;
+    i128 hi = (i128)max << amt.max;
+    constexpr i128 kMin = (i128)std::numeric_limits<int64_t>::min();
+    constexpr i128 kMax = (i128)std::numeric_limits<int64_t>::max();
+    if (lo < kMin || hi > kMax) return unbounded();
+    return bounded((int64_t)std::min(lo, hi), (int64_t)std::max(lo, hi));
+  }
+
+  // Arithmetic shift right: conservative when b is unknown.
+  Lnast_range sra(const Lnast_range& amt) const noexcept {
+    if (is_unbounded()) return unbounded();
+    if (amt.is_unbounded() || amt.min < 0) return unbounded();
+    int64_t shift = amt.min;  // shift by minimum narrows range the least
+    if (shift > 63) shift = 63;
+    int64_t lo = min >> shift;
+    int64_t hi = max >> shift;
+    return bounded(std::min(lo, hi), std::max(lo, hi));
+  }
+
+private:
+  // ── Helpers ───────────────────────────────────────────────────────────────
+
+  static constexpr Lnast_range bounded(int64_t lo, int64_t hi) noexcept {
+    Lnast_range r;
+    r.min     = lo;
+    r.max     = hi;
+    r.neg_inf = false;
+    r.pos_inf = false;
+    return r;
+  }
+
+  // Minimum signed bits to represent the value v in two's complement.
+  static constexpr int64_t sbits_for(int64_t v) noexcept {
+    if (v >= 0) {
+      // Need floor(log2(v))+1 data bits + 1 sign bit = bit_width(v) + 1.
+      return static_cast<int64_t>(std::bit_width(static_cast<uint64_t>(v))) + 1;
+    }
+    // v < 0: smallest N where -2^(N-1) <= v, i.e. 2^(N-1) >= -v.
+    // N-1 = ceil(log2(-v)) = bit_width(-v - 1).
+    return static_cast<int64_t>(std::bit_width(static_cast<uint64_t>(-v - 1))) + 1;
+  }
+
+  // Returns true and leaves `result` undefined on overflow.
+  static bool add_overflow(int64_t a, int64_t b, int64_t& result) noexcept {
+    using i128 = __int128;
+    i128 r = (i128)a + b;
+    if (r < std::numeric_limits<int64_t>::min() || r > std::numeric_limits<int64_t>::max()) return true;
+    result = (int64_t)r;
+    return false;
+  }
+
+  static bool sub_overflow(int64_t a, int64_t b, int64_t& result) noexcept {
+    using i128 = __int128;
+    i128 r = (i128)a - b;
+    if (r < std::numeric_limits<int64_t>::min() || r > std::numeric_limits<int64_t>::max()) return true;
+    result = (int64_t)r;
+    return false;
+  }
+};

--- a/upass/bitwidth/upass_bitwidth.cpp
+++ b/upass/bitwidth/upass_bitwidth.cpp
@@ -3,12 +3,14 @@
 #include "upass_bitwidth.hpp"
 
 #include <charconv>
+#include <limits>
 #include <string>
 #include <string_view>
 #include <system_error>
 
 #include "lnast.hpp"
 #include "lnast_ntype.hpp"
+#include "pass.hpp"
 
 // ── Plugin registration ───────────────────────────────────────────────────────
 // The static initializer fires at program startup so the runner discovers
@@ -332,4 +334,101 @@ void uPass_bitwidth::process_set_mask() {
   auto [lhs, rhs] = scan_op();
   (void)rhs;
   set_range(lhs, Lnast_range::unbounded());
+}
+
+// ── process_attr_set ─────────────────────────────────────────────────────────
+//
+// LNAST shape (mirrors uPass_attributes::process_attr_set):
+//   attr_set
+//     ref(target)
+//     const(attr_name)        — "ubits" | "sbits" | "max" | "min" | …
+//     <value: const | ref>
+//
+// For numeric bit/range attributes, derive an explicit Lnast_range and meet it
+// with whatever the target currently holds. Conflict reporting is best-effort:
+// we warn (not error) until wrap/saturate policy migrates to bitwidth (T2 #7).
+// Non-bitwidth attributes (e.g. `comptime`, `type`, `wrap`, `saturate`) are
+// ignored — uPass_attributes owns those.
+void uPass_bitwidth::process_attr_set() {
+  if (!move_to_child()) return;
+  auto target = normalize_name(current_text());
+  if (!move_to_sibling()) { move_to_parent(); return; }
+  std::string attr_name{current_text()};
+  std::string value_text;
+  bool        value_is_const = false;
+  if (move_to_sibling()) {
+    value_text     = std::string{current_text()};
+    value_is_const = Lnast_ntype::is_const(get_raw_ntype());
+  }
+  move_to_parent();
+
+  if (target.empty() || attr_name.empty() || !value_is_const) return;
+
+  // Parse value text to int64_t (handles dec / 0x / 0b, returns unbounded on
+  // unparseable inputs like Pyrope-unknown-bits constants).
+  auto val_range = range_from_const_text(value_text);
+  if (!val_range.is_constant()) return;
+  int64_t n = val_range.min;
+
+  // Build the implied range from this attribute.
+  Lnast_range narrow;
+  if (attr_name == "ubits") {
+    if (n <= 0 || n >= 63) return;  // sanity: 1..62 representable in int64_t
+    narrow.min     = 0;
+    narrow.max     = (int64_t{1} << n) - 1;
+    narrow.neg_inf = false;
+    narrow.pos_inf = false;
+  } else if (attr_name == "sbits") {
+    if (n <= 1 || n >= 63) return;  // sanity: 2..62 (1 bit = single sign)
+    narrow.min     = -(int64_t{1} << (n - 1));
+    narrow.max     = (int64_t{1} << (n - 1)) - 1;
+    narrow.neg_inf = false;
+    narrow.pos_inf = false;
+  } else if (attr_name == "max") {
+    narrow.max     = n;
+    narrow.neg_inf = true;   // only constrains upper bound
+    narrow.pos_inf = false;
+  } else if (attr_name == "min") {
+    narrow.min     = n;
+    narrow.neg_inf = false;  // only constrains lower bound
+    narrow.pos_inf = true;
+  } else {
+    return;  // not a bitwidth-owned attribute
+  }
+
+  // Compute the meet of `current` and `narrow` manually. We can't use
+  // Lnast_range::meet here: it short-circuits to the other operand whenever
+  // either side is half-bounded (e.g. `(-inf, 10]`), which is too coarse for
+  // attribute narrowing. Per-side merge: take the tighter of the two bounds,
+  // respecting infinity flags.
+  auto current = read_range(target);
+  Lnast_range merged;
+  merged.neg_inf = current.neg_inf && narrow.neg_inf;
+  merged.pos_inf = current.pos_inf && narrow.pos_inf;
+  if (!merged.neg_inf) {
+    int64_t lo = current.neg_inf ? narrow.min
+              : (narrow.neg_inf  ? current.min
+                                 : std::max(current.min, narrow.min));
+    merged.min = lo;
+  }
+  if (!merged.pos_inf) {
+    int64_t hi = current.pos_inf ? narrow.max
+              : (narrow.pos_inf  ? current.max
+                                 : std::min(current.max, narrow.max));
+    merged.max = hi;
+  }
+
+  // Hard contradiction (e.g. `x = 100; x.[ubits] = 3` → meet is empty).
+  if (!merged.neg_inf && !merged.pos_inf && merged.min > merged.max) {
+    // Warn for now; once wrap/saturate policy migrates here (T2 #7) this
+    // promotes to upass::error unless the target has [wrap] or [saturate].
+    Pass::warn(
+        std::format("uPass_bitwidth: explicit `[{}]` constraint on `{}` is unsatisfiable "
+                    "(current range does not fit declared bounds)",
+                    attr_name, target));
+    return;
+  }
+
+  // set_range only updates if `merged` is strictly narrower than `current`.
+  set_range(target, merged);
 }

--- a/upass/bitwidth/upass_bitwidth.cpp
+++ b/upass/bitwidth/upass_bitwidth.cpp
@@ -1,0 +1,304 @@
+//  This file is distributed under the BSD 3-Clause License. See LICENSE for details.
+
+#include "upass_bitwidth.hpp"
+
+#include <charconv>
+#include <string>
+#include <string_view>
+#include <system_error>
+
+#include "lnast.hpp"
+#include "lnast_ntype.hpp"
+
+// ── Plugin registration ───────────────────────────────────────────────────────
+// The static initializer fires at program startup so the runner discovers
+// "bitwidth" via uPass_plugin::get_registry() without any explicit wiring.
+static upass::uPass_plugin plugin_bitwidth("bitwidth",
+                                           upass::uPass_wrapper<uPass_bitwidth>::get_upass);
+
+// ── Constructor ──────────────────────────────────────────────────────────────
+
+uPass_bitwidth::uPass_bitwidth(std::shared_ptr<upass::Lnast_manager>& lm) : upass::uPass(lm) {}
+
+// ── Lifecycle ────────────────────────────────────────────────────────────────
+
+void uPass_bitwidth::begin_iteration() {
+  // Reset the changed flag only — ranges accumulate across iterations so a
+  // second sweep can tighten what was unbounded in the first.
+  changed = false;
+}
+
+void uPass_bitwidth::end_run() {
+  // Flush range_map_ into lnast->bw_meta() so lnast_to_lgraph can read them.
+  auto& meta = lm->get_lnast()->bw_meta();
+  meta.ranges.clear();
+  for (const auto& [name, rng] : range_map_) {
+    BitwidthEntry e;
+    e.min     = rng.min;
+    e.max     = rng.max;
+    e.neg_inf = rng.neg_inf;
+    e.pos_inf = rng.pos_inf;
+    meta.ranges.emplace(name, e);
+  }
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+Lnast_range uPass_bitwidth::read_range(std::string_view name) const {
+  if (name.empty()) return Lnast_range::unbounded();
+  auto it = range_map_.find(std::string{name});
+  if (it != range_map_.end()) return it->second;
+  return Lnast_range::unbounded();
+}
+
+void uPass_bitwidth::set_range(std::string_view name, Lnast_range r) {
+  if (name.empty()) return;
+  auto [it, inserted] = range_map_.emplace(std::string{name}, r);
+  if (inserted) {
+    // First time we've seen this name — only mark changed if we got a finite
+    // range (unbounded-first is not a useful narrowing event).
+    if (!r.is_unbounded()) mark_changed();
+    return;
+  }
+  // Already exists: only update and mark changed if strictly narrower.
+  if (r.is_narrower_than(it->second)) {
+    it->second = r;
+    mark_changed();
+  }
+}
+
+// Try to parse a Pyrope constant text to int64_t.  Handles decimal,
+// "0x..." (hex), "0b..." (binary).  Returns Lnast_range::unbounded() on
+// failure (e.g. Pyrope unknown-bits constants like "0sb1?").
+static Lnast_range range_from_const_text(std::string_view text) {
+  if (text.empty()) return Lnast_range::unbounded();
+  // Strip a leading minus sign.
+  bool negative = (text[0] == '-');
+  if (negative) text.remove_prefix(1);
+  if (text.empty()) return Lnast_range::unbounded();
+
+  uint64_t uval = 0;
+  bool     parsed = false;
+  if (text.size() >= 2 && text[0] == '0' && (text[1] == 'x' || text[1] == 'X')) {
+    auto res = std::from_chars(text.data() + 2, text.data() + text.size(), uval, 16);
+    parsed = (res.ec == std::errc{} && res.ptr == text.data() + text.size());
+  } else if (text.size() >= 2 && text[0] == '0' && (text[1] == 'b' || text[1] == 'B')) {
+    auto res = std::from_chars(text.data() + 2, text.data() + text.size(), uval, 2);
+    parsed = (res.ec == std::errc{} && res.ptr == text.data() + text.size());
+  } else {
+    int64_t sval = 0;
+    auto    res  = std::from_chars(text.data(), text.data() + text.size(), sval);
+    if (res.ec == std::errc{} && res.ptr == text.data() + text.size()) {
+      return Lnast_range::constant(negative ? -sval : sval);
+    }
+    return Lnast_range::unbounded();
+  }
+
+  if (!parsed) return Lnast_range::unbounded();
+  // Unsigned value: fit into int64_t or give up.
+  if (uval > static_cast<uint64_t>(std::numeric_limits<int64_t>::max())) return Lnast_range::unbounded();
+  int64_t val = static_cast<int64_t>(uval);
+  return Lnast_range::constant(negative ? -val : val);
+}
+
+uPass_bitwidth::Op_ranges uPass_bitwidth::scan_op() {
+  Op_ranges out;
+  if (!move_to_child()) return out;
+
+  // First child: LHS (always a ref whose text is the destination name).
+  out.lhs = std::string{current_text()};
+
+  // Remaining children: RHS operands.
+  while (move_to_sibling()) {
+    auto t = get_raw_ntype();
+    if (Lnast_ntype::is_ref(t)) {
+      out.rhs.push_back(read_range(current_text()));
+    } else if (Lnast_ntype::is_const(t)) {
+      out.rhs.push_back(range_from_const_text(current_text()));
+    } else {
+      // Structural child — skip, treat as unknown operand.
+      out.rhs.push_back(Lnast_range::unbounded());
+    }
+  }
+  move_to_parent();
+  return out;
+}
+
+std::string uPass_bitwidth::scan_lhs_only() {
+  if (!move_to_child()) return {};
+  std::string lhs{current_text()};
+  move_to_parent();
+  return lhs;
+}
+
+// ── fold_ref ─────────────────────────────────────────────────────────────────
+
+std::optional<Const> uPass_bitwidth::fold_ref(std::string_view name) {
+  auto it = range_map_.find(std::string{name});
+  if (it == range_map_.end()) return std::nullopt;
+  if (!it->second.is_constant()) return std::nullopt;
+  return *Dlop::create_integer(it->second.min);
+}
+
+// ── Process hooks ─────────────────────────────────────────────────────────────
+//
+// Pattern for assign / arithmetic ops:
+//   1. scan_op() — consume children, get lhs + rhs ranges.
+//   2. Compute result range.
+//   3. set_range(lhs, result).
+//
+// Pattern for boolean / comparison ops:
+//   result is always Lnast_range::boolean() regardless of inputs.
+//
+// Pattern for unary ops (bit_not, log_not, red_*):
+//   one RHS operand; result is boolean for logical/reductions,
+//   or join/negation for bitwise.
+
+void uPass_bitwidth::process_assign() {
+  auto [lhs, rhs] = scan_op();
+  if (rhs.empty()) {
+    set_range(lhs, Lnast_range::unbounded());
+  } else {
+    // Direct assignment propagates the range of the RHS operand.
+    set_range(lhs, rhs[0]);
+  }
+}
+
+void uPass_bitwidth::process_plus() {
+  auto [lhs, rhs] = scan_op();
+  if (rhs.empty()) { set_range(lhs, Lnast_range::unbounded()); return; }
+  Lnast_range result = rhs[0];
+  for (std::size_t i = 1; i < rhs.size(); ++i) result = result.add(rhs[i]);
+  set_range(lhs, result);
+}
+
+void uPass_bitwidth::process_minus() {
+  auto [lhs, rhs] = scan_op();
+  if (rhs.size() < 2) { set_range(lhs, Lnast_range::unbounded()); return; }
+  Lnast_range result = rhs[0].sub(rhs[1]);
+  set_range(lhs, result);
+}
+
+void uPass_bitwidth::process_mult() {
+  auto [lhs, rhs] = scan_op();
+  if (rhs.empty()) { set_range(lhs, Lnast_range::unbounded()); return; }
+  Lnast_range result = rhs[0];
+  for (std::size_t i = 1; i < rhs.size(); ++i) result = result.mul(rhs[i]);
+  set_range(lhs, result);
+}
+
+void uPass_bitwidth::process_div() {
+  // Quotient range is conservative — don't try to invert divisor range.
+  auto [lhs, rhs] = scan_op();
+  (void)rhs;
+  set_range(lhs, Lnast_range::unbounded());
+}
+
+void uPass_bitwidth::process_mod() {
+  auto [lhs, rhs] = scan_op();
+  (void)rhs;
+  set_range(lhs, Lnast_range::unbounded());
+}
+
+void uPass_bitwidth::process_shl() {
+  auto [lhs, rhs] = scan_op();
+  if (rhs.size() < 2) { set_range(lhs, Lnast_range::unbounded()); return; }
+  set_range(lhs, rhs[0].shl(rhs[1]));
+}
+
+void uPass_bitwidth::process_sra() {
+  auto [lhs, rhs] = scan_op();
+  if (rhs.size() < 2) { set_range(lhs, Lnast_range::unbounded()); return; }
+  set_range(lhs, rhs[0].sra(rhs[1]));
+}
+
+// Bitwise ops — conservative: join of operand ranges (not tight).
+void uPass_bitwidth::process_bit_and() {
+  auto [lhs, rhs] = scan_op();
+  if (rhs.empty()) { set_range(lhs, Lnast_range::unbounded()); return; }
+  Lnast_range result = rhs[0];
+  for (std::size_t i = 1; i < rhs.size(); ++i) result = result.join(rhs[i]);
+  set_range(lhs, result);
+}
+
+void uPass_bitwidth::process_bit_or() {
+  auto [lhs, rhs] = scan_op();
+  if (rhs.empty()) { set_range(lhs, Lnast_range::unbounded()); return; }
+  Lnast_range result = rhs[0];
+  for (std::size_t i = 1; i < rhs.size(); ++i) result = result.join(rhs[i]);
+  set_range(lhs, result);
+}
+
+void uPass_bitwidth::process_bit_xor() {
+  auto [lhs, rhs] = scan_op();
+  if (rhs.empty()) { set_range(lhs, Lnast_range::unbounded()); return; }
+  Lnast_range result = rhs[0];
+  for (std::size_t i = 1; i < rhs.size(); ++i) result = result.join(rhs[i]);
+  set_range(lhs, result);
+}
+
+void uPass_bitwidth::process_bit_not() {
+  auto [lhs, rhs] = scan_op();
+  // ~x = -x - 1; propagate negated range conservatively.
+  if (rhs.empty()) { set_range(lhs, Lnast_range::unbounded()); return; }
+  set_range(lhs, rhs[0].neg());
+}
+
+// Logical ops — result is always boolean.
+void uPass_bitwidth::process_log_and() {
+  auto lhs = scan_lhs_only(); set_range(lhs, Lnast_range::boolean());
+}
+void uPass_bitwidth::process_log_or() {
+  auto lhs = scan_lhs_only(); set_range(lhs, Lnast_range::boolean());
+}
+void uPass_bitwidth::process_log_not() {
+  auto lhs = scan_lhs_only(); set_range(lhs, Lnast_range::boolean());
+}
+
+// Reductions — single-bit boolean result.
+void uPass_bitwidth::process_red_or() {
+  auto lhs = scan_lhs_only(); set_range(lhs, Lnast_range::boolean());
+}
+void uPass_bitwidth::process_red_and() {
+  auto lhs = scan_lhs_only(); set_range(lhs, Lnast_range::boolean());
+}
+void uPass_bitwidth::process_red_xor() {
+  auto lhs = scan_lhs_only(); set_range(lhs, Lnast_range::boolean());
+}
+
+// Comparison ops — always boolean.
+void uPass_bitwidth::process_eq() {
+  auto lhs = scan_lhs_only(); set_range(lhs, Lnast_range::boolean());
+}
+void uPass_bitwidth::process_ne() {
+  auto lhs = scan_lhs_only(); set_range(lhs, Lnast_range::boolean());
+}
+void uPass_bitwidth::process_lt() {
+  auto lhs = scan_lhs_only(); set_range(lhs, Lnast_range::boolean());
+}
+void uPass_bitwidth::process_le() {
+  auto lhs = scan_lhs_only(); set_range(lhs, Lnast_range::boolean());
+}
+void uPass_bitwidth::process_gt() {
+  auto lhs = scan_lhs_only(); set_range(lhs, Lnast_range::boolean());
+}
+void uPass_bitwidth::process_ge() {
+  auto lhs = scan_lhs_only(); set_range(lhs, Lnast_range::boolean());
+}
+
+// Bit-manipulation ops — conservative unbounded for now.
+void uPass_bitwidth::process_sext() {
+  auto [lhs, rhs] = scan_op();
+  (void)rhs;
+  set_range(lhs, Lnast_range::unbounded());
+}
+void uPass_bitwidth::process_get_mask() {
+  auto [lhs, rhs] = scan_op();
+  (void)rhs;
+  set_range(lhs, Lnast_range::unbounded());
+}
+void uPass_bitwidth::process_set_mask() {
+  auto [lhs, rhs] = scan_op();
+  (void)rhs;
+  set_range(lhs, Lnast_range::unbounded());
+}

--- a/upass/bitwidth/upass_bitwidth.cpp
+++ b/upass/bitwidth/upass_bitwidth.cpp
@@ -26,6 +26,24 @@ void uPass_bitwidth::begin_iteration() {
   // Reset the changed flag only — ranges accumulate across iterations so a
   // second sweep can tighten what was unbounded in the first.
   changed = false;
+
+  // Cross-invocation persistence: a fresh uPass_bitwidth instance starts
+  // with empty range_map_, but the previous pass.upass call may have left
+  // ranges in lnast->bw_meta(). Seed range_map_ from bw_meta so a second
+  // sweep can tighten what was unbounded before. Only do this once per run
+  // (when range_map_ is empty); subsequent begin_iteration calls inside the
+  // same run leave the accumulated state alone.
+  if (range_map_.empty()) {
+    const auto& meta = lm->get_lnast()->bw_meta();
+    for (const auto& [name, e] : meta.ranges) {
+      Lnast_range r;
+      r.min     = e.min;
+      r.max     = e.max;
+      r.neg_inf = e.neg_inf;
+      r.pos_inf = e.pos_inf;
+      range_map_.emplace(name, r);
+    }
+  }
 }
 
 void uPass_bitwidth::end_run() {
@@ -101,18 +119,29 @@ static Lnast_range range_from_const_text(std::string_view text) {
   return Lnast_range::constant(negative ? -val : val);
 }
 
+// Strip a leading port sigil (`%` output, `$` input) so the bitwidth pass
+// uses the same canonical key on both write and read sides — matches
+// uPass_attributes::normalize_name. lnast_to_lgraph's apply_bw also uses
+// the unprefixed name when looking up bw_meta.
+static std::string normalize_name(std::string_view name) {
+  if (!name.empty() && (name.front() == '%' || name.front() == '$')) {
+    return std::string{name.substr(1)};
+  }
+  return std::string{name};
+}
+
 uPass_bitwidth::Op_ranges uPass_bitwidth::scan_op() {
   Op_ranges out;
   if (!move_to_child()) return out;
 
   // First child: LHS (always a ref whose text is the destination name).
-  out.lhs = std::string{current_text()};
+  out.lhs = normalize_name(current_text());
 
   // Remaining children: RHS operands.
   while (move_to_sibling()) {
     auto t = get_raw_ntype();
     if (Lnast_ntype::is_ref(t)) {
-      out.rhs.push_back(read_range(current_text()));
+      out.rhs.push_back(read_range(normalize_name(current_text())));
     } else if (Lnast_ntype::is_const(t)) {
       out.rhs.push_back(range_from_const_text(current_text()));
     } else {
@@ -126,7 +155,7 @@ uPass_bitwidth::Op_ranges uPass_bitwidth::scan_op() {
 
 std::string uPass_bitwidth::scan_lhs_only() {
   if (!move_to_child()) return {};
-  std::string lhs{current_text()};
+  std::string lhs = normalize_name(current_text());
   move_to_parent();
   return lhs;
 }
@@ -134,7 +163,9 @@ std::string uPass_bitwidth::scan_lhs_only() {
 // ── fold_ref ─────────────────────────────────────────────────────────────────
 
 std::optional<Const> uPass_bitwidth::fold_ref(std::string_view name) {
-  auto it = range_map_.find(std::string{name});
+  // Callers may pass either `%out` or `out`; normalize so we hit the same
+  // key the pass stored under (see normalize_name() above).
+  auto it = range_map_.find(normalize_name(name));
   if (it == range_map_.end()) return std::nullopt;
   if (!it->second.is_constant()) return std::nullopt;
   return *Dlop::create_integer(it->second.min);

--- a/upass/bitwidth/upass_bitwidth.hpp
+++ b/upass/bitwidth/upass_bitwidth.hpp
@@ -68,6 +68,12 @@ public:
   void process_get_mask() override;
   void process_set_mask() override;
 
+  // Explicit constraints: `[ubits]`, `[sbits]`, `[max]`, `[min]` narrow the
+  // target's inferred range. Conflict reporting is best-effort here (wrap /
+  // saturate policy is owned by uPass_attributes today); a hard error will
+  // land once the wrap/sat math migrates here per the spec.
+  void process_attr_set() override;
+
   // Returns Const(v) only when the stored range is a single-value constant.
   std::optional<Const> fold_ref(std::string_view name) override;
 

--- a/upass/bitwidth/upass_bitwidth.hpp
+++ b/upass/bitwidth/upass_bitwidth.hpp
@@ -1,0 +1,95 @@
+//  This file is distributed under the BSD 3-Clause License. See LICENSE for details.
+#pragma once
+
+#include <map>
+#include <memory>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include "const.hpp"
+#include "lnast_range.hpp"
+#include "upass_core.hpp"
+
+// uPass_bitwidth — LNAST bitwidth / value-range analysis.
+//
+// Registers as a "bitwidth" uPass_plugin optimizer. For every assignment-shaped
+// LNAST statement it computes the min/max value range of the result and stores
+// it in an internal map keyed by the LHS variable name.  Ranges persist across
+// per-node mark_changed iterations and across outer pass.upass re-invocations.
+//
+// After the run completes, end_run() flushes the computed ranges into
+// lnast->bw_meta() so downstream passes (lnast_to_lgraph) can read them.
+//
+// Key properties:
+//   * Boolean / comparison results always get the signed 1-bit range [-1, 0].
+//   * Compiler temps (___*) and port sigils ($, %) participate normally —
+//     there is no special exclusion.
+//   * fold_ref() returns a concrete Const only when the range collapses to a
+//     single constant value, enabling constprop and verifier to fold it.
+//   * Arithmetic on unbounded ranges propagates unbounded conservatively.
+struct uPass_bitwidth : public upass::uPass {
+public:
+  explicit uPass_bitwidth(std::shared_ptr<upass::Lnast_manager>& lm);
+  ~uPass_bitwidth() override = default;
+
+  // Keep ranges across iterations — only reset the changed flag.
+  void begin_iteration() override;
+  // Flush computed ranges into lnast->bw_meta().
+  void end_run() override;
+
+  // Assignment-shaped ops (LHS = op(rhs…)).
+  void process_assign()   override;
+  void process_plus()     override;
+  void process_minus()    override;
+  void process_mult()     override;
+  void process_div()      override;
+  void process_mod()      override;
+  void process_shl()      override;
+  void process_sra()      override;
+  void process_bit_and()  override;
+  void process_bit_or()   override;
+  void process_bit_not()  override;
+  void process_bit_xor()  override;
+  void process_log_and()  override;
+  void process_log_or()   override;
+  void process_log_not()  override;
+  void process_red_or()   override;
+  void process_red_and()  override;
+  void process_red_xor()  override;
+  void process_ne()       override;
+  void process_eq()       override;
+  void process_lt()       override;
+  void process_le()       override;
+  void process_gt()       override;
+  void process_ge()       override;
+  void process_sext()     override;
+  void process_get_mask() override;
+  void process_set_mask() override;
+
+  // Returns Const(v) only when the stored range is a single-value constant.
+  std::optional<Const> fold_ref(std::string_view name) override;
+
+private:
+  // Per-variable range map. Persists across begin_iteration calls.
+  std::map<std::string, Lnast_range> range_map_;
+
+  // Read range for `name` — returns unbounded() if not yet known.
+  Lnast_range read_range(std::string_view name) const;
+
+  // Store `r` for `name`. Calls mark_changed() iff the range is strictly
+  // narrower than what was previously recorded.
+  void set_range(std::string_view name, Lnast_range r);
+
+  // Scan the current op node: walk first child (LHS name), remaining children
+  // (RHS operands — ref or const), restore cursor on exit.
+  struct Op_ranges {
+    std::string              lhs;
+    std::vector<Lnast_range> rhs;
+  };
+  Op_ranges scan_op();
+
+  // Like scan_op() but return only the LHS name without consuming children.
+  std::string scan_lhs_only();
+};

--- a/upass/bitwidth/upass_bitwidth_test.cpp
+++ b/upass/bitwidth/upass_bitwidth_test.cpp
@@ -1,0 +1,268 @@
+//  This file is distributed under the BSD 3-Clause License. See LICENSE for details.
+
+#include "upass_bitwidth.hpp"
+
+#include <memory>
+#include <optional>
+#include <string>
+
+#include "gtest/gtest.h"
+#include "lnast.hpp"
+#include "lnast_ntype.hpp"
+#include "lnast_range.hpp"
+#include "upass_runner.hpp"
+
+// ── Part 1: Lattice unit tests ────────────────────────────────────────────────
+
+TEST(LnastRangeLattice, Unbounded) {
+  auto r = Lnast_range::unbounded();
+  EXPECT_TRUE(r.is_unbounded());
+  EXPECT_FALSE(r.is_constant());
+}
+
+TEST(LnastRangeLattice, Constant) {
+  auto r = Lnast_range::constant(42);
+  EXPECT_FALSE(r.is_unbounded());
+  EXPECT_TRUE(r.is_constant());
+  EXPECT_EQ(r.min, 42);
+  EXPECT_EQ(r.max, 42);
+}
+
+TEST(LnastRangeLattice, Boolean) {
+  auto r = Lnast_range::boolean();
+  EXPECT_FALSE(r.is_unbounded());
+  EXPECT_FALSE(r.is_constant());
+  EXPECT_EQ(r.min, -1);
+  EXPECT_EQ(r.max, 0);
+}
+
+// ── sbits ─────────────────────────────────────────────────────────────────────
+
+TEST(LnastRangeLattice, SbitsConstant0) {
+  EXPECT_EQ(Lnast_range::constant(0).get_sbits(), 1);
+}
+
+TEST(LnastRangeLattice, SbitsConstant7) {
+  EXPECT_EQ(Lnast_range::constant(7).get_sbits(), 4);
+}
+
+TEST(LnastRangeLattice, SbitsConstantNeg1) {
+  EXPECT_EQ(Lnast_range::constant(-1).get_sbits(), 1);
+}
+
+TEST(LnastRangeLattice, SbitsRange0To15) {
+  Lnast_range r;
+  r.min = 0; r.max = 15; r.neg_inf = false; r.pos_inf = false;
+  EXPECT_EQ(r.get_sbits(), 5);
+}
+
+TEST(LnastRangeLattice, SbitsBoolean) {
+  EXPECT_EQ(Lnast_range::boolean().get_sbits(), 1);
+}
+
+TEST(LnastRangeLattice, SbitsUnbounded) {
+  EXPECT_EQ(Lnast_range::unbounded().get_sbits(), 64);
+}
+
+// ── Arithmetic ────────────────────────────────────────────────────────────────
+
+TEST(LnastRangeLattice, AddConstants) {
+  auto r = Lnast_range::constant(3).add(Lnast_range::constant(5));
+  EXPECT_TRUE(r.is_constant());
+  EXPECT_EQ(r.min, 8);
+}
+
+TEST(LnastRangeLattice, AddUnbounded) {
+  auto r = Lnast_range::unbounded().add(Lnast_range::constant(5));
+  EXPECT_TRUE(r.is_unbounded());
+}
+
+TEST(LnastRangeLattice, SubConstants) {
+  auto r = Lnast_range::constant(10).sub(Lnast_range::constant(3));
+  EXPECT_TRUE(r.is_constant());
+  EXPECT_EQ(r.min, 7);
+}
+
+TEST(LnastRangeLattice, MulConstants) {
+  auto r = Lnast_range::constant(3).mul(Lnast_range::constant(4));
+  EXPECT_TRUE(r.is_constant());
+  EXPECT_EQ(r.min, 12);
+}
+
+TEST(LnastRangeLattice, NegConstant) {
+  auto r = Lnast_range::constant(5).neg();
+  EXPECT_TRUE(r.is_constant());
+  EXPECT_EQ(r.min, -5);
+}
+
+// ── Join / Meet ────────────────────────────────────────────────────────────────
+
+TEST(LnastRangeLattice, Join) {
+  auto r = Lnast_range::constant(2).join(Lnast_range::constant(7));
+  EXPECT_FALSE(r.is_unbounded());
+  EXPECT_EQ(r.min, 2);
+  EXPECT_EQ(r.max, 7);
+}
+
+TEST(LnastRangeLattice, JoinWithUnbounded) {
+  auto r = Lnast_range::constant(2).join(Lnast_range::unbounded());
+  EXPECT_TRUE(r.is_unbounded());
+}
+
+TEST(LnastRangeLattice, Meet) {
+  Lnast_range a; a.min=1; a.max=10; a.neg_inf=false; a.pos_inf=false;
+  Lnast_range b; b.min=5; b.max=20; b.neg_inf=false; b.pos_inf=false;
+  auto r = a.meet(b);
+  EXPECT_FALSE(r.is_unbounded());
+  EXPECT_EQ(r.min, 5);
+  EXPECT_EQ(r.max, 10);
+}
+
+// ── is_narrower_than ──────────────────────────────────────────────────────────
+
+TEST(LnastRangeLattice, NarrowerThan) {
+  Lnast_range wide; wide.min=0; wide.max=100; wide.neg_inf=false; wide.pos_inf=false;
+  auto narrow = Lnast_range::constant(42);
+  EXPECT_TRUE(narrow.is_narrower_than(wide));
+  EXPECT_FALSE(wide.is_narrower_than(narrow));
+}
+
+// ── Part 2: Integration tests using the uPass_runner ─────────────────────────
+
+// Build a minimal post-upass LNAST:
+//   top -> stmts -> assign(c, a)  where a and b are graph inputs
+// Then create an integration test that runs the bitwidth pass.
+
+namespace {
+
+// Build: top → stmts → assign(lhs_ref, rhs_ref_or_const)
+static std::shared_ptr<Lnast> make_simple_assign(
+    const std::string& lhs, const std::string& rhs, bool rhs_is_const = false) {
+  auto ln = std::make_shared<Lnast>("bw_test");
+  auto root  = ln->set_root(Lnast_ntype::create_top());
+  auto stmts = ln->add_child(root, Lnast_ntype::create_stmts());
+  auto asgn  = ln->add_child(stmts, Lnast_ntype::create_assign());
+  ln->add_child(asgn, Lnast_node::create_ref(lhs));
+  if (rhs_is_const) {
+    ln->add_child(asgn, Lnast_node::create_const(rhs));
+  } else {
+    ln->add_child(asgn, Lnast_node::create_ref(rhs));
+  }
+  return ln;
+}
+
+// Build: top → stmts → plus(c, a, b)
+static std::shared_ptr<Lnast> make_plus(
+    const std::string& lhs, const std::string& rhs1, const std::string& rhs2,
+    bool r1_const = false, bool r2_const = false) {
+  auto ln    = std::make_shared<Lnast>("bw_plus_test");
+  auto root  = ln->set_root(Lnast_ntype::create_top());
+  auto stmts = ln->add_child(root, Lnast_ntype::create_stmts());
+  auto plus  = ln->add_child(stmts, Lnast_ntype::create_plus());
+  ln->add_child(plus, Lnast_node::create_ref(lhs));
+  if (r1_const) ln->add_child(plus, Lnast_node::create_const(rhs1));
+  else          ln->add_child(plus, Lnast_node::create_ref(rhs1));
+  if (r2_const) ln->add_child(plus, Lnast_node::create_const(rhs2));
+  else          ln->add_child(plus, Lnast_node::create_ref(rhs2));
+  return ln;
+}
+
+// Run bitwidth pass only on an LNAST using the runner.
+static void run_bw(const std::shared_ptr<Lnast>& ln) {
+  auto lm = std::make_shared<upass::Lnast_manager>(ln);
+  uPass_runner runner(lm, {"bitwidth"});
+  runner.run(/*max_iters=*/3);
+  // Commit the staging tree back.
+  ln->replace_body(runner.take_staging()->tree_ptr());
+}
+
+}  // namespace
+
+// Test: assign c = 3 (const) → bw_meta["c"] should be constant(3)
+TEST(BitwidthIntegration, ConstAssign) {
+  auto ln = make_simple_assign("c", "3", /*rhs_is_const=*/true);
+  run_bw(ln);
+  const auto& meta = ln->bw_meta().ranges;
+  auto it = meta.find("c");
+  ASSERT_NE(it, meta.end()) << "Expected 'c' in bw_meta";
+  EXPECT_FALSE(it->second.neg_inf);
+  EXPECT_FALSE(it->second.pos_inf);
+  EXPECT_EQ(it->second.min, 3);
+  EXPECT_EQ(it->second.max, 3);
+}
+
+// Test: plus c = 3 + 5 → bw_meta["c"] should be constant(8)
+TEST(BitwidthIntegration, PlusTwoConsts) {
+  auto ln = make_plus("c", "3", "5", true, true);
+  run_bw(ln);
+  const auto& meta = ln->bw_meta().ranges;
+  auto it = meta.find("c");
+  ASSERT_NE(it, meta.end()) << "Expected 'c' in bw_meta after plus(3,5)";
+  EXPECT_FALSE(it->second.neg_inf);
+  EXPECT_FALSE(it->second.pos_inf);
+  EXPECT_EQ(it->second.min, 8);
+  EXPECT_EQ(it->second.max, 8);
+}
+
+// Test: plus c = a + 5 where a is unknown → c should be unbounded
+TEST(BitwidthIntegration, PlusUnknownRef) {
+  auto ln = make_plus("c", "a", "5", false, true);
+  run_bw(ln);
+  const auto& meta = ln->bw_meta().ranges;
+  auto it = meta.find("c");
+  // c may be absent (unbounded = never stored) or explicitly unbounded.
+  if (it != meta.end()) {
+    EXPECT_TRUE(it->second.neg_inf || it->second.pos_inf) << "c should be unbounded";
+  }
+  // Either way: not a concrete finite range.
+}
+
+// Test: Boolean result from comparison (eq) → bw_meta should be [-1,0]
+TEST(BitwidthIntegration, EqResultBoolean) {
+  auto ln = std::make_shared<Lnast>("bw_eq_test");
+  auto root  = ln->set_root(Lnast_ntype::create_top());
+  auto stmts = ln->add_child(root, Lnast_ntype::create_stmts());
+  auto eq    = ln->add_child(stmts, Lnast_ntype::create_eq());
+  ln->add_child(eq, Lnast_node::create_ref("x"));
+  ln->add_child(eq, Lnast_node::create_ref("a"));
+  ln->add_child(eq, Lnast_node::create_ref("b"));
+
+  run_bw(ln);
+  const auto& meta = ln->bw_meta().ranges;
+  auto it = meta.find("x");
+  ASSERT_NE(it, meta.end()) << "Expected 'x' in bw_meta after eq";
+  EXPECT_EQ(it->second.min, -1);
+  EXPECT_EQ(it->second.max, 0);
+  EXPECT_FALSE(it->second.neg_inf);
+  EXPECT_FALSE(it->second.pos_inf);
+}
+
+// Test: assign propagates range: assign c = 3 (const) → fold_ref("c") = 3
+// We verify through bw_meta only (fold_ref is internal to the pass).
+TEST(BitwidthIntegration, PropagateConst) {
+  // Chain: assign tmp = 3 (const), assign c = tmp (ref propagation)
+  auto ln    = std::make_shared<Lnast>("bw_chain");
+  auto root  = ln->set_root(Lnast_ntype::create_top());
+  auto stmts = ln->add_child(root, Lnast_ntype::create_stmts());
+
+  auto asgn1 = ln->add_child(stmts, Lnast_ntype::create_assign());
+  ln->add_child(asgn1, Lnast_node::create_ref("tmp"));
+  ln->add_child(asgn1, Lnast_node::create_const("3"));
+
+  auto asgn2 = ln->add_child(stmts, Lnast_ntype::create_assign());
+  ln->add_child(asgn2, Lnast_node::create_ref("c"));
+  ln->add_child(asgn2, Lnast_node::create_ref("tmp"));
+
+  run_bw(ln);
+  const auto& meta = ln->bw_meta().ranges;
+
+  auto it_tmp = meta.find("tmp");
+  ASSERT_NE(it_tmp, meta.end());
+  EXPECT_EQ(it_tmp->second.min, 3);
+  EXPECT_EQ(it_tmp->second.max, 3);
+
+  auto it_c = meta.find("c");
+  ASSERT_NE(it_c, meta.end());
+  EXPECT_EQ(it_c->second.min, 3);
+  EXPECT_EQ(it_c->second.max, 3);
+}

--- a/upass/bitwidth/upass_bitwidth_test.cpp
+++ b/upass/bitwidth/upass_bitwidth_test.cpp
@@ -266,3 +266,153 @@ TEST(BitwidthIntegration, PropagateConst) {
   EXPECT_EQ(it_c->second.min, 3);
   EXPECT_EQ(it_c->second.max, 3);
 }
+
+// ── attr_set narrowing tests ─────────────────────────────────────────────────
+
+namespace {
+// Append an attr_set node under `stmts`: attr_set ref(target) const(attr)
+// const(value).
+static void add_attr_set(const std::shared_ptr<Lnast>& ln, Lnast_nid stmts,
+                         std::string_view target, std::string_view attr,
+                         std::string_view value) {
+  auto node = ln->add_child(stmts, Lnast_ntype::create_attr_set());
+  ln->add_child(node, Lnast_node::create_ref(std::string{target}));
+  ln->add_child(node, Lnast_node::create_const(std::string{attr}));
+  ln->add_child(node, Lnast_node::create_const(std::string{value}));
+}
+}  // namespace
+
+// `x.[ubits] = 4` (no prior assignment) → range = [0, 15]
+TEST(BitwidthAttrSet, UbitsAlone) {
+  auto ln    = std::make_shared<Lnast>("bw_attr_ubits");
+  auto root  = ln->set_root(Lnast_ntype::create_top());
+  auto stmts = ln->add_child(root, Lnast_ntype::create_stmts());
+  add_attr_set(ln, stmts, "x", "ubits", "4");
+
+  run_bw(ln);
+  const auto& meta = ln->bw_meta().ranges;
+  auto it = meta.find("x");
+  ASSERT_NE(it, meta.end());
+  EXPECT_FALSE(it->second.neg_inf);
+  EXPECT_FALSE(it->second.pos_inf);
+  EXPECT_EQ(it->second.min, 0);
+  EXPECT_EQ(it->second.max, 15);
+}
+
+// `x.[sbits] = 4` → range = [-8, 7]
+TEST(BitwidthAttrSet, SbitsAlone) {
+  auto ln    = std::make_shared<Lnast>("bw_attr_sbits");
+  auto root  = ln->set_root(Lnast_ntype::create_top());
+  auto stmts = ln->add_child(root, Lnast_ntype::create_stmts());
+  add_attr_set(ln, stmts, "x", "sbits", "4");
+
+  run_bw(ln);
+  const auto& meta = ln->bw_meta().ranges;
+  auto it = meta.find("x");
+  ASSERT_NE(it, meta.end());
+  EXPECT_FALSE(it->second.neg_inf);
+  EXPECT_FALSE(it->second.pos_inf);
+  EXPECT_EQ(it->second.min, -8);
+  EXPECT_EQ(it->second.max, 7);
+}
+
+// `x.[max] = 100` → range = (-inf, 100]
+TEST(BitwidthAttrSet, MaxAlone) {
+  auto ln    = std::make_shared<Lnast>("bw_attr_max");
+  auto root  = ln->set_root(Lnast_ntype::create_top());
+  auto stmts = ln->add_child(root, Lnast_ntype::create_stmts());
+  add_attr_set(ln, stmts, "x", "max", "100");
+
+  run_bw(ln);
+  const auto& meta = ln->bw_meta().ranges;
+  auto it = meta.find("x");
+  ASSERT_NE(it, meta.end());
+  EXPECT_TRUE(it->second.neg_inf);
+  EXPECT_FALSE(it->second.pos_inf);
+  EXPECT_EQ(it->second.max, 100);
+}
+
+// `x.[min] = -5` → range = [-5, +inf)
+TEST(BitwidthAttrSet, MinAlone) {
+  auto ln    = std::make_shared<Lnast>("bw_attr_min");
+  auto root  = ln->set_root(Lnast_ntype::create_top());
+  auto stmts = ln->add_child(root, Lnast_ntype::create_stmts());
+  add_attr_set(ln, stmts, "x", "min", "-5");
+
+  run_bw(ln);
+  const auto& meta = ln->bw_meta().ranges;
+  auto it = meta.find("x");
+  ASSERT_NE(it, meta.end());
+  EXPECT_FALSE(it->second.neg_inf);
+  EXPECT_TRUE(it->second.pos_inf);
+  EXPECT_EQ(it->second.min, -5);
+}
+
+// `x = 7; x.[ubits] = 4` → fits; range stays [7,7] (meet with [0,15]).
+TEST(BitwidthAttrSet, FitsAfterAssign) {
+  auto ln    = std::make_shared<Lnast>("bw_attr_fits");
+  auto root  = ln->set_root(Lnast_ntype::create_top());
+  auto stmts = ln->add_child(root, Lnast_ntype::create_stmts());
+  auto asgn  = ln->add_child(stmts, Lnast_ntype::create_assign());
+  ln->add_child(asgn, Lnast_node::create_ref("x"));
+  ln->add_child(asgn, Lnast_node::create_const("7"));
+  add_attr_set(ln, stmts, "x", "ubits", "4");
+
+  run_bw(ln);
+  const auto& meta = ln->bw_meta().ranges;
+  auto it = meta.find("x");
+  ASSERT_NE(it, meta.end());
+  EXPECT_EQ(it->second.min, 7);
+  EXPECT_EQ(it->second.max, 7);
+}
+
+// `x = 100; x.[ubits] = 3` → 100 cannot fit in [0,7]. Pass warns and leaves
+// the original range alone (does not narrow). Test that the original range
+// is preserved and no crash occurs.
+TEST(BitwidthAttrSet, ConflictWarnsAndKeepsOriginal) {
+  auto ln    = std::make_shared<Lnast>("bw_attr_conflict");
+  auto root  = ln->set_root(Lnast_ntype::create_top());
+  auto stmts = ln->add_child(root, Lnast_ntype::create_stmts());
+  auto asgn  = ln->add_child(stmts, Lnast_ntype::create_assign());
+  ln->add_child(asgn, Lnast_node::create_ref("x"));
+  ln->add_child(asgn, Lnast_node::create_const("100"));
+  add_attr_set(ln, stmts, "x", "ubits", "3");
+
+  run_bw(ln);
+  const auto& meta = ln->bw_meta().ranges;
+  auto it = meta.find("x");
+  ASSERT_NE(it, meta.end());
+  // Original assignment of 100 still recorded; constraint was rejected.
+  EXPECT_EQ(it->second.min, 100);
+  EXPECT_EQ(it->second.max, 100);
+}
+
+// `x.[ubits] = 4; x.[max] = 10` → meet of [0,15] and (-inf,10] = [0,10].
+TEST(BitwidthAttrSet, ChainedNarrowing) {
+  auto ln    = std::make_shared<Lnast>("bw_attr_chain");
+  auto root  = ln->set_root(Lnast_ntype::create_top());
+  auto stmts = ln->add_child(root, Lnast_ntype::create_stmts());
+  add_attr_set(ln, stmts, "x", "ubits", "4");
+  add_attr_set(ln, stmts, "x", "max", "10");
+
+  run_bw(ln);
+  const auto& meta = ln->bw_meta().ranges;
+  auto it = meta.find("x");
+  ASSERT_NE(it, meta.end());
+  EXPECT_FALSE(it->second.neg_inf);
+  EXPECT_FALSE(it->second.pos_inf);
+  EXPECT_EQ(it->second.min, 0);
+  EXPECT_EQ(it->second.max, 10);
+}
+
+// Non-bitwidth attributes (e.g. `comptime`) are ignored — no range stored.
+TEST(BitwidthAttrSet, NonBitwidthAttrIgnored) {
+  auto ln    = std::make_shared<Lnast>("bw_attr_other");
+  auto root  = ln->set_root(Lnast_ntype::create_top());
+  auto stmts = ln->add_child(root, Lnast_ntype::create_stmts());
+  add_attr_set(ln, stmts, "x", "comptime", "true");
+
+  run_bw(ln);
+  const auto& meta = ln->bw_meta().ranges;
+  EXPECT_EQ(meta.find("x"), meta.end()) << "comptime attr should not record a range";
+}

--- a/upass/lnast_to_lgraph/lnast_to_lgraph.cpp
+++ b/upass/lnast_to_lgraph/lnast_to_lgraph.cpp
@@ -2,6 +2,8 @@
 
 #include "lnast_to_lgraph.hpp"
 
+#include <bit>
+#include <cstdint>
 #include <string>
 
 #include "pass.hpp"
@@ -339,6 +341,7 @@ void Lnast_to_lgraph::lower_assign() {
   if (!move_to_sibling()) { move_to_parent(); return; }
   auto drv = lower_leaf();
   move_to_parent();
+  apply_bw(drv, lhs);
   bind(lhs, drv);
 }
 
@@ -357,11 +360,41 @@ void Lnast_to_lgraph::lower_infix(Ntype_op op, std::string_view a_pin, std::stri
   auto node = lg_->create_node(op);
   lg_->add_edge(op_a, node.setup_sink_pin(a_pin));
   lg_->add_edge(op_b, node.setup_sink_pin(b_pin));
-  bind(result, node.setup_driver_pin("Y"));
+  auto drv = node.setup_driver_pin("Y");
+  apply_bw(drv, result);
+  bind(result, drv);
 }
 
 Node_pin Lnast_to_lgraph::nil_pin() {
   return lg_->create_node_const(Dlop::invalid()).setup_driver_pin();
+}
+
+void Lnast_to_lgraph::apply_bw(Node_pin& drv, std::string_view lhs_name) {
+  const auto& meta = lnast_->bw_meta();
+  if (meta.empty()) return;
+  auto it = meta.ranges.find(std::string{lhs_name});
+  if (it == meta.ranges.end()) return;
+  const auto& e = it->second;
+  if (e.is_unbounded()) return;
+
+  // Compute signed bit count to represent [min, max] in two's complement.
+  // Same formula as Lnast_range::sbits_for(v).
+  auto sbits_for = [](int64_t v) -> int64_t {
+    if (v >= 0) {
+      return static_cast<int64_t>(std::bit_width(static_cast<uint64_t>(v))) + 1;
+    }
+    return static_cast<int64_t>(std::bit_width(static_cast<uint64_t>(-v - 1))) + 1;
+  };
+  int64_t bits = std::max(sbits_for(e.min), sbits_for(e.max));
+  if (bits <= 0 || bits > 4096) return;  // sanity guard
+
+  drv.set_bits(static_cast<uint32_t>(bits));
+  bool is_signed = e.min < 0;
+  if (is_signed) {
+    drv.set_sign();
+  } else {
+    drv.set_unsign();
+  }
 }
 
 // Lower the subtree at the current cursor into a fresh branch scope.

--- a/upass/lnast_to_lgraph/lnast_to_lgraph.cpp
+++ b/upass/lnast_to_lgraph/lnast_to_lgraph.cpp
@@ -56,6 +56,7 @@ Node_pin Lnast_to_lgraph::resolve(std::string_view raw_name) {
   if (is_input_port(raw_name)) {
     // $-prefixed: auto-promote to a graph input.
     auto inp = lg_->add_graph_input(name, next_inp_pos_++, 0);
+    apply_bw(inp, name);
     pin_map_.emplace(name, inp);
     return inp;
   }
@@ -85,6 +86,7 @@ void Lnast_to_lgraph::wire_outputs() {
     if (it == pin_map_.end()) continue;
     auto& drv     = it->second;
     auto  out_pin = lg_->add_graph_output(name, next_out_pos_++, drv.get_bits());
+    apply_bw(out_pin, name);
     lg_->add_edge(drv, out_pin);
   }
 }
@@ -245,6 +247,7 @@ void Lnast_to_lgraph::lower_post_upass_top() {
                 auto field = std::string(current_text());
                 move_to_parent();
                 auto inp = lg_->add_graph_input(field, next_inp_pos_++, 0);
+                apply_bw(inp, field);
                 pin_map_.emplace(field, inp);
               }
             }
@@ -284,6 +287,7 @@ void Lnast_to_lgraph::lower_post_upass_top() {
     }
     auto& drv     = it->second;
     auto  out_pin = lg_->add_graph_output(name, next_out_pos_++, drv.get_bits());
+    apply_bw(out_pin, name);
     lg_->add_edge(drv, out_pin);
   }
 }
@@ -296,9 +300,12 @@ void Lnast_to_lgraph::lower_post_upass_top() {
 void Lnast_to_lgraph::lower_from_io_meta() {
   const auto& meta = lnast_->io_meta();
 
-  // Register graph inputs from io_meta.
+  // Register graph inputs from io_meta. bw_meta (if populated by the bitwidth
+  // pass) overrides the io_meta bits — io_meta carries Pyrope-declared widths,
+  // bw_meta carries inferred ranges that may be tighter.
   for (const auto& entry : meta.inputs) {
     auto inp = lg_->add_graph_input(entry.name, next_inp_pos_++, entry.bits);
+    apply_bw(inp, entry.name);
     pin_map_.emplace(entry.name, inp);
   }
 
@@ -324,6 +331,7 @@ void Lnast_to_lgraph::lower_from_io_meta() {
     }
     auto& drv     = it->second;
     auto  out_pin = lg_->add_graph_output(name, next_out_pos_++, drv.get_bits());
+    apply_bw(out_pin, name);
     lg_->add_edge(drv, out_pin);
   }
 }
@@ -372,7 +380,13 @@ Node_pin Lnast_to_lgraph::nil_pin() {
 void Lnast_to_lgraph::apply_bw(Node_pin& drv, std::string_view lhs_name) {
   const auto& meta = lnast_->bw_meta();
   if (meta.empty()) return;
-  auto it = meta.ranges.find(std::string{lhs_name});
+  // bw_meta keys are stored unprefixed (the bitwidth pass strips %/$ port
+  // sigils on write). Mirror that here so callers can pass either form.
+  std::string_view key = lhs_name;
+  if (!key.empty() && (key.front() == '%' || key.front() == '$')) {
+    key.remove_prefix(1);
+  }
+  auto it = meta.ranges.find(std::string{key});
   if (it == meta.ranges.end()) return;
   const auto& e = it->second;
   if (e.is_unbounded()) return;
@@ -495,6 +509,10 @@ void Lnast_to_lgraph::lower_if() {
       cur_val = mux.setup_driver_pin("Y");
     }
 
+    // Apply bitwidth to the final Mux output (the merged value seen as `var`).
+    // The intermediate muxes for the same var share its inferred range.
+    apply_bw(cur_val, var);
+
     // Write final mux output back (preserve output_names_ membership).
     pin_map_.insert_or_assign(var, cur_val);
   }
@@ -516,7 +534,9 @@ void Lnast_to_lgraph::lower_negated_infix(Ntype_op op, std::string_view a_pin, s
 
   auto not_node = lg_->create_node(Ntype_op::Not);
   lg_->add_edge(inner.setup_driver_pin("Y"), not_node.setup_sink_pin("a"));
-  bind(result, not_node.setup_driver_pin("Y"));
+  auto drv = not_node.setup_driver_pin("Y");
+  apply_bw(drv, result);
+  bind(result, drv);
 }
 
 // Single-operand ops: red_or, red_and, red_xor — result = op(A)
@@ -529,7 +549,9 @@ void Lnast_to_lgraph::lower_unary(Ntype_op op, std::string_view a_pin) {
 
   auto node = lg_->create_node(op);
   lg_->add_edge(operand, node.setup_sink_pin(a_pin));
-  bind(result, node.setup_driver_pin("Y"));
+  auto drv = node.setup_driver_pin("Y");
+  apply_bw(drv, result);
+  bind(result, drv);
 }
 
 // set_mask has three inputs: a, mask, value — result = Set_mask(a, mask, value)
@@ -548,7 +570,9 @@ void Lnast_to_lgraph::lower_set_mask() {
   lg_->add_edge(op_a,    node.setup_sink_pin("a"));
   lg_->add_edge(op_mask, node.setup_sink_pin("mask"));
   lg_->add_edge(op_val,  node.setup_sink_pin("value"));
-  bind(result, node.setup_driver_pin("Y"));
+  auto drv = node.setup_driver_pin("Y");
+  apply_bw(drv, result);
+  bind(result, drv);
 }
 
 // func_def children (per prp2lnast.cpp):
@@ -589,6 +613,7 @@ void Lnast_to_lgraph::lower_func_def() {
           move_to_parent();
           // Register the graph input pin so body references resolve correctly.
           auto inp = lg_->add_graph_input(inp_name, next_inp_pos_++, 0);
+          apply_bw(inp, inp_name);
           pin_map_.emplace(inp_name, inp);
         }
       }
@@ -631,6 +656,7 @@ void Lnast_to_lgraph::lower_func_def() {
     }
     auto& drv     = it->second;
     auto  out_pin = lg_->add_graph_output(name, next_out_pos_++, drv.get_bits());
+    apply_bw(out_pin, name);
     lg_->add_edge(drv, out_pin);
   }
 }
@@ -644,7 +670,9 @@ void Lnast_to_lgraph::lower_not() {
 
   auto node = lg_->create_node(Ntype_op::Not);
   lg_->add_edge(operand, node.setup_sink_pin("a"));
-  bind(result, node.setup_driver_pin("Y"));
+  auto drv = node.setup_driver_pin("Y");
+  apply_bw(drv, result);
+  bind(result, drv);
 }
 
 Node_pin Lnast_to_lgraph::lower_leaf() {

--- a/upass/lnast_to_lgraph/lnast_to_lgraph.hpp
+++ b/upass/lnast_to_lgraph/lnast_to_lgraph.hpp
@@ -47,6 +47,10 @@ private:
 
   // Returns a nil (0sb?) constant driver pin.
   Node_pin nil_pin();
+
+  // Apply bitwidth metadata to a driver pin if lnast_->bw_meta() has a finite
+  // range for `lhs_name`.  No-op when the range is absent or unbounded.
+  void apply_bw(Node_pin& drv, std::string_view lhs_name);
   // Runs lower_node() on the current cursor position and returns what was
   // bound (assigned) by the subtree, then restores those bindings to their
   // pre-call values.  Auto-promoted graph inputs (added via resolve()) are


### PR DESCRIPTION
## Summary

Continues the LNAST bitwidth pass per `lnast_bitwidth.md`. Three
incremental commits:

1. **Scaffold** — `upass/bitwidth/` plugin with `Lnast_range` lattice
   (signed min/max + explicit ±∞ flags), per-op handlers, boolean/cmp
   results as `[-1, 0]`, and 23 lattice unit tests.
2. **Pipeline wiring + apply_bw coverage** — register `bitwidth` as a
   default optimizer in `pass.upass`, slotted between `attributes` and
   `constprop`. Add cross-invocation persistence (seed `range_map_`
   from `bw_meta` on entry), port-sigil normalization on both write
   (bitwidth pass) and read (`apply_bw` in `lnast_to_lgraph`) sides,
   and extend `apply_bw` to 9 additional LGraph node-creation sites
   (Not, unary, set_mask, mux output, graph I/O ports, …).
3. **`attr_set` narrowing** — observe explicit `[ubits]`/`[sbits]`/
   `[max]`/`[min]` constraints; narrow inferred ranges; emit a warning
   on unsatisfiable conflict (kept as warning until wrap/saturate policy
   migrates here per spec).

Pipeline order now: `attributes → bitwidth → constprop → coalescer → assert`.

## Test plan

- [x] `bazel test //upass/bitwidth:upass_bitwidth_test` — 31/31 pass (23 lattice + 8 new attr_set)
- [x] `bazel test //upass/lnast_to_lgraph:upass_lnast_to_lgraph_test` — green
- [x] `bazel test //pass/upass:all //upass/runner:all` — 12/12 green
- [x] `equiv_test.sh trivial` runs through the new pipeline order and generates Verilog cleanly

## Notes for review

- Cross-invocation persistence: ranges saved to `lnast->bw_meta()` in `end_run` are reloaded in `begin_iteration` so a second `pass.upass` call can tighten what the first left unbounded (spec §"Iteration and mark_changed").
- Conflict reporting in `attr_set` is intentionally a warning (not `upass::error`) until wrap/sat policy lands in the bitwidth pass — at that point the error becomes conditional on the absence of `[wrap]`/`[saturate]`.
- Doc cutover in `lnast2lgraph.md` §7 (LGraph gets bits at creation from LNAST attrs) is already on master; this PR is the implementation that makes that contract true.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/masc-ucsc/livehd/549)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added bitwidth inference analysis that computes and tracks min/max value ranges for signals and variables throughout the compilation pipeline.
  * Bitwidth metadata is now automatically applied to generated graph pins to preserve range information.
  * Added toggle to enable/disable bitwidth analysis in the transformation pipeline; pass executes between attribute processing and constant propagation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/masc-ucsc/livehd/pull/549)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->