### PR TITLE
upass/bitwidth: attr_get delegation, wrap/sat math extraction, tests

### DIFF
--- a/upass/attributes/BUILD
+++ b/upass/attributes/BUILD
@@ -16,6 +16,7 @@ cc_library(
     deps = [
         "//core",
         "//lnast",
+        "//upass/bitwidth:wrap_sat_hdr",
         "//upass/core:upass",
     ],
     alwayslink = True,

--- a/upass/attributes/upass_attributes_phase2.cpp
+++ b/upass/attributes/upass_attributes_phase2.cpp
@@ -16,6 +16,8 @@
 // The evaluator writes every successful fold to `tmp_fold` so the override
 // of `fold_ref` substitutes the value at every downstream consumer.
 
+#include <algorithm>
+#include <bit>
 #include <cctype>
 #include <cstdint>
 #include <optional>
@@ -24,6 +26,7 @@
 #include <utility>
 
 #include "const.hpp"
+#include "lnast.hpp"
 #include "lnast_ntype.hpp"
 #include "upass_attributes.hpp"
 #include "upass_attributes_sticky.hpp"
@@ -171,6 +174,16 @@ std::optional<Const> uPass_attributes::derive_max(std::string_view base) const {
       return rb->second;
     }
   }
+  // Bitwidth-pass inferred range: takes precedence over type-derived bounds
+  // because the bitwidth pass may have proven a tighter range from data flow
+  // (e.g. `a:u8 = b & 0xF` → max=15 even though u8 type max is 255).
+  if (lm) {
+    const auto& meta = lm->get_lnast()->bw_meta();
+    auto        it   = meta.ranges.find(std::string{base});
+    if (it != meta.ranges.end() && !it->second.pos_inf) {
+      return *Dlop::create_integer(it->second.max);
+    }
+  }
   // Type-derived.
   if (auto* ti = lookup_type_info(base); ti && ti->bits != 0) {
     if (ti->kind == Numeric_kind::unsigned_int) {
@@ -200,6 +213,14 @@ std::optional<Const> uPass_attributes::derive_min(std::string_view base) const {
       return rb->first;
     }
   }
+  // Bitwidth-pass inferred range: see derive_max for rationale.
+  if (lm) {
+    const auto& meta = lm->get_lnast()->bw_meta();
+    auto        it   = meta.ranges.find(std::string{base});
+    if (it != meta.ranges.end() && !it->second.neg_inf) {
+      return *Dlop::create_integer(it->second.min);
+    }
+  }
   if (auto* ti = lookup_type_info(base); ti && ti->bits != 0) {
     if (ti->kind == Numeric_kind::unsigned_int) {
       return *Dlop::create_integer(0);
@@ -218,19 +239,50 @@ std::optional<Const> uPass_attributes::derive_min(std::string_view base) const {
 }
 
 std::optional<Const> uPass_attributes::derive_bits(std::string_view base, std::string_view variant) const {
-  auto v = resolve_value(base);
-  if (!v) {
-    return std::nullopt;
+  // Concrete value (constprop already proved it) is the most precise source.
+  if (auto v = resolve_value(base); v) {
+    if (variant == "ubits") {
+      return *Dlop::create_integer(static_cast<int64_t>(bits_unsigned(*v)));
+    }
+    if (variant == "sbits") {
+      return *Dlop::create_integer(static_cast<int64_t>(bits_signed(*v)));
+    }
+    // "bits": the natural width — unsigned for non-negative values, signed
+    // (including the sign bit) for negative values, 0 for zero, 1 for -1.
+    return *Dlop::create_integer(static_cast<int64_t>(bits_natural(*v)));
   }
-  if (variant == "ubits") {
-    return *Dlop::create_integer(static_cast<int64_t>(bits_unsigned(*v)));
+  // No concrete value yet — try the bitwidth pass's inferred range. Same
+  // sbits-of-min-and-max convention as apply_bw() in lnast_to_lgraph.
+  if (lm) {
+    const auto& meta = lm->get_lnast()->bw_meta();
+    auto        it   = meta.ranges.find(std::string{base});
+    if (it != meta.ranges.end() && !it->second.is_unbounded()) {
+      const auto& e = it->second;
+      auto        sbits_for = [](int64_t x) -> int64_t {
+        if (x >= 0) {
+          return static_cast<int64_t>(std::bit_width(static_cast<uint64_t>(x))) + 1;
+        }
+        return static_cast<int64_t>(std::bit_width(static_cast<uint64_t>(-x - 1))) + 1;
+      };
+      const int64_t sbits = std::max(sbits_for(e.min), sbits_for(e.max));
+      if (variant == "sbits") {
+        return *Dlop::create_integer(sbits);
+      }
+      if (variant == "ubits") {
+        // ubits is only meaningful when the range is non-negative.
+        if (e.min < 0) {
+          return *Dlop::create_integer(0);
+        }
+        return *Dlop::create_integer(sbits - 1);  // drop sign bit
+      }
+      // "bits": unsigned width when non-negative, signed otherwise.
+      if (e.min >= 0) {
+        return *Dlop::create_integer(sbits - 1);
+      }
+      return *Dlop::create_integer(sbits);
+    }
   }
-  if (variant == "sbits") {
-    return *Dlop::create_integer(static_cast<int64_t>(bits_signed(*v)));
-  }
-  // "bits": the natural width — unsigned for non-negative values, signed
-  // (including the sign bit) for negative values, 0 for zero, 1 for -1.
-  return *Dlop::create_integer(static_cast<int64_t>(bits_natural(*v)));
+  return std::nullopt;
 }
 
 std::optional<Const> uPass_attributes::derive_comptime(std::string_view base, std::string_view base_text) const {

--- a/upass/attributes/upass_attributes_phase5.cpp
+++ b/upass/attributes/upass_attributes_phase5.cpp
@@ -32,6 +32,7 @@
 #include "const.hpp"
 #include "upass_attributes.hpp"
 #include "upass_utils.hpp"
+#include "wrap_sat.hpp"  // narrowing math now lives in //upass/bitwidth (T2 #7)
 
 namespace {
 
@@ -42,62 +43,14 @@ bool is_truthy(std::string_view v) {
   return v != "false" && v != "0";
 }
 
-// Wrap (modulo) and saturate clamps for the given numeric type. n==0 means
-// the type's bit width is unknown and no narrowing is possible.
-Const wrap_to_unsigned(const Const& v, uint32_t n) {
-  if (n == 0 || v.is_invalid() || v.is_string() || v.has_unknowns() || v.is_nil()) {
-    return v;
-  }
-  // Build a 2^n - 1 mask and apply.
-  Const mask;
-  mask = Dlop::get_mask_value(n);
-  return *v.and_op(mask);
-}
-
-Const wrap_to_signed(const Const& v, uint32_t n) {
-  if (n == 0 || v.is_invalid() || v.is_string() || v.has_unknowns() || v.is_nil()) {
-    return v;
-  }
-  // Two's-complement wrap to n bits: take low n bits, then sign-extend if
-  // the n-th-1 bit is set. Const's adjust_bits already implements this for
-  // signed widths.
-  return *v.adjust_bits(n);
-}
-
-Const saturate_unsigned(const Const& v, uint32_t n) {
-  if (n == 0 || v.is_invalid() || v.is_string() || v.has_unknowns() || v.is_nil()) {
-    return v;
-  }
-  Const lo;
-  lo = Dlop::create_integer(0);
-  Const hi;
-  hi = Dlop::get_mask_value(n);
-  if (v.is_negative()) {
-    return lo;
-  }
-  // v > hi — compare via subtraction sign.
-  if (v.sub_op(hi)->is_positive() && !v.same_repr(hi)) {
-    return hi;
-  }
-  return v;
-}
-
-Const saturate_signed(const Const& v, uint32_t n) {
-  if (n == 0 || v.is_invalid() || v.is_string() || v.has_unknowns() || v.is_nil()) {
-    return v;
-  }
-  Const hi;
-  hi = Dlop::get_mask_value(n - 1);
-  Const lo;
-  lo = Dlop::get_neg_mask_value(n - 1);
-  if (v.sub_op(hi)->is_positive() && !v.same_repr(hi)) {
-    return hi;
-  }
-  if (lo.sub_op(v)->is_positive() && !v.same_repr(lo)) {
-    return lo;
-  }
-  return v;
-}
+// Wrap / saturate narrowing math moved to upass/bitwidth/wrap_sat.hpp.
+// Re-export under the same names so the rest of this file's call sites
+// stay unchanged and policy/trigger semantics here remain isolated from
+// the value-math.
+using upass::bitwidth::wrap_to_unsigned;
+using upass::bitwidth::wrap_to_signed;
+using upass::bitwidth::saturate_unsigned;
+using upass::bitwidth::saturate_signed;
 
 }  // namespace
 

--- a/upass/bitwidth/BUILD
+++ b/upass/bitwidth/BUILD
@@ -14,12 +14,27 @@ cc_library(
     includes = ["."],
     visibility = ["//visibility:public"],
     deps = [
+        ":wrap_sat_hdr",
         "//core",
         "//lnast",
         "//pass/common:pass",
         "//upass/core:upass",
     ],
     alwayslink = True,  # ensures the static plugin_bitwidth registration fires
+)
+
+# Header-only utility: pure wrap/saturate narrowing math. Lives in
+# upass/bitwidth/ per lnast_bitwidth.md ("max/min-dependent operations
+# live in bitwidth") but exposed as a separate target so consumers like
+# upass/attributes/ can pull in the helpers without linking the
+# bitwidth plugin's static registration.
+cc_library(
+    name = "wrap_sat_hdr",
+    hdrs = ["wrap_sat.hpp"],
+    copts = COPTS,
+    includes = ["."],
+    visibility = ["//visibility:public"],
+    deps = ["//core"],
 )
 
 cc_test(

--- a/upass/bitwidth/upass_bitwidth_test.cpp
+++ b/upass/bitwidth/upass_bitwidth_test.cpp
@@ -445,3 +445,56 @@ TEST(BitwidthAttrSet, NonBitwidthAttrIgnored) {
   const auto& meta = ln->bw_meta().ranges;
   EXPECT_EQ(meta.find("x"), meta.end()) << "comptime attr should not record a range";
 }
+
+// ── Cross-invocation persistence (T3 #8) ─────────────────────────────────────
+//
+// First sweep proves nothing about `c = a + b` because a and b are unknown
+// refs (no prior writes). After the first run, the caller injects ranges for
+// a and b into bw_meta — simulating a prior pass.upass call that constrained
+// them — and re-runs bitwidth. The second sweep's begin_iteration seeds
+// range_map_ from bw_meta, so the plus(a, b) operands now resolve to finite
+// ranges and `c` is proven [a.min + b.min, a.max + b.max].
+TEST(BitwidthCrossInvocation, TightenAfterReseed) {
+  auto ln = make_plus("c", "a", "b");
+
+  // First pass: a and b are unknown, c remains unbounded (or absent).
+  run_bw(ln);
+  {
+    const auto& meta = ln->bw_meta().ranges;
+    auto        it   = meta.find("c");
+    if (it != meta.end()) {
+      EXPECT_TRUE(it->second.neg_inf || it->second.pos_inf) << "c should still be unbounded after first sweep";
+    }
+  }
+
+  // Inject ranges for a and b into bw_meta — what a prior pass.upass call
+  // would have left behind for an earlier-bounded register.
+  auto& meta_w  = ln->bw_meta();
+  BitwidthEntry ea{};
+  ea.min     = 0;
+  ea.max     = 7;
+  ea.neg_inf = false;
+  ea.pos_inf = false;
+  meta_w.ranges["a"] = ea;
+  BitwidthEntry eb{};
+  eb.min     = 1;
+  eb.max     = 2;
+  eb.neg_inf = false;
+  eb.pos_inf = false;
+  meta_w.ranges["b"] = eb;
+
+  // Second pass: begin_iteration reloads a,b into range_map_; plus computes
+  // c = [0+1, 7+2] = [1, 9].
+  run_bw(ln);
+
+  const auto& meta = ln->bw_meta().ranges;
+  auto        it_c = meta.find("c");
+  ASSERT_NE(it_c, meta.end()) << "c should be proven finite after re-seed";
+  EXPECT_FALSE(it_c->second.neg_inf);
+  EXPECT_FALSE(it_c->second.pos_inf);
+  EXPECT_EQ(it_c->second.min, 1);
+  EXPECT_EQ(it_c->second.max, 9);
+  // Re-seeded inputs are preserved across end_run (write-clear-rewrite).
+  EXPECT_NE(meta.find("a"), meta.end());
+  EXPECT_NE(meta.find("b"), meta.end());
+}

--- a/upass/bitwidth/wrap_sat.hpp
+++ b/upass/bitwidth/wrap_sat.hpp
@@ -1,0 +1,81 @@
+//  This file is distributed under the BSD 3-Clause License. See LICENSE for details.
+#pragma once
+
+// Wrap / saturate narrowing math for the bitwidth pass.
+//
+// Per `lnast_bitwidth.md`, value-math that depends on bits / range
+// information lives in the bitwidth pass. The wrap and saturate
+// narrowings are pure Const transformations parameterised by a bit
+// width and signedness:
+//
+//   wrap(v, n)      — two's-complement modulo 2^n
+//   saturate(v, n)  — clamp to the [min, max] of an n-bit value
+//
+// `uPass_attributes` still records the wrap / saturate POLICY (i.e.
+// which variables carry the `[wrap]` / `[saturate]` attribute), but
+// delegates the actual value-math to these helpers via the public
+// API below. Both passes can include this header — it is inline-only
+// and has no link dependency, just <const.hpp>.
+
+#include <cstdint>
+
+#include "const.hpp"
+
+namespace upass::bitwidth {
+
+// Wrap an unsigned value to `n` bits using a 2^n − 1 mask.
+// `n == 0` (unknown width) leaves `v` unchanged. Invalid / unknown-bits
+// constants pass through.
+inline Const wrap_to_unsigned(const Const& v, uint32_t n) {
+  if (n == 0 || v.is_invalid() || v.is_string() || v.has_unknowns() || v.is_nil()) {
+    return v;
+  }
+  Const mask = *Dlop::get_mask_value(n);
+  return *v.and_op(mask);
+}
+
+// Two's-complement wrap to `n` signed bits: take the low `n` bits, then
+// sign-extend if the (n-1)-th bit is set. Implemented via
+// `Const::adjust_bits` which already does exactly this for signed widths.
+inline Const wrap_to_signed(const Const& v, uint32_t n) {
+  if (n == 0 || v.is_invalid() || v.is_string() || v.has_unknowns() || v.is_nil()) {
+    return v;
+  }
+  return *v.adjust_bits(n);
+}
+
+// Saturate an unsigned value to [0, 2^n − 1]. Negative inputs clamp to 0;
+// inputs greater than the max clamp to the max.
+inline Const saturate_unsigned(const Const& v, uint32_t n) {
+  if (n == 0 || v.is_invalid() || v.is_string() || v.has_unknowns() || v.is_nil()) {
+    return v;
+  }
+  Const lo = *Dlop::create_integer(0);
+  Const hi = *Dlop::get_mask_value(n);
+  if (v.is_negative()) {
+    return lo;
+  }
+  // v > hi — compare via subtraction sign.
+  if (v.sub_op(hi)->is_positive() && !v.same_repr(hi)) {
+    return hi;
+  }
+  return v;
+}
+
+// Saturate a signed value to [-2^(n-1), 2^(n-1) − 1].
+inline Const saturate_signed(const Const& v, uint32_t n) {
+  if (n == 0 || v.is_invalid() || v.is_string() || v.has_unknowns() || v.is_nil()) {
+    return v;
+  }
+  Const hi = *Dlop::get_mask_value(n - 1);
+  Const lo = *Dlop::get_neg_mask_value(n - 1);
+  if (v.sub_op(hi)->is_positive() && !v.same_repr(hi)) {
+    return hi;
+  }
+  if (lo.sub_op(v)->is_positive() && !v.same_repr(lo)) {
+    return lo;
+  }
+  return v;
+}
+
+}  // namespace upass::bitwidth

--- a/upass/lnast_to_lgraph/lnast_to_lgraph.cpp
+++ b/upass/lnast_to_lgraph/lnast_to_lgraph.cpp
@@ -430,12 +430,21 @@ void Lnast_to_lgraph::apply_bw(Node_pin& drv, std::string_view lhs_name) {
     return;  // sanity guard
   }
 
-  drv.set_bits(static_cast<uint32_t>(bits));
+  // `add_graph_output` returns the SINK view of the output port; set_bits /
+  // set_sign require a driver pin. Swap to the driver side first when we're
+  // applying bw to a graph-output sink. (Other call sites pass real drivers
+  // — Sum's "Y", graph_input return, etc. — and is_graph_output() is false
+  // there, so this is a no-op.)
+  Node_pin target = drv;
+  if (target.is_sink() && target.is_graph_output()) {
+    target = target.change_to_driver_from_graph_out_sink();
+  }
+  target.set_bits(static_cast<uint32_t>(bits));
   bool is_signed = e.min < 0;
   if (is_signed) {
-    drv.set_sign();
+    target.set_sign();
   } else {
-    drv.set_unsign();
+    target.set_unsign();
   }
 }
 

--- a/upass/lnast_to_lgraph/lnast_to_lgraph_test.cpp
+++ b/upass/lnast_to_lgraph/lnast_to_lgraph_test.cpp
@@ -591,3 +591,86 @@ TEST(LnastToLgraph, SsaRenameMultiAssign) {
   EXPECT_EQ(count_op(lg, Ntype_op::Mux), 0);
   EXPECT_EQ(count_op(lg, Ntype_op::Xor), 0);
 }
+
+// ── Bitwidth → LGraph pin bits (T3 #9) ───────────────────────────────────────
+
+namespace {
+// Helper: fetch the bit width of a named graph input/output pin.
+static uint32_t get_input_bits(Lgraph* lg, const std::string& name) {
+  uint32_t bits = 0;
+  lg->each_graph_input([&](const Node_pin& pin) {
+    if (pin.has_name() && pin.get_name() == name) {
+      bits = pin.get_bits();
+    }
+  });
+  return bits;
+}
+static uint32_t get_output_bits(Lgraph* lg, const std::string& name) {
+  uint32_t bits = 0;
+  lg->each_graph_output([&](const Node_pin& pin) {
+    if (pin.has_name() && pin.get_name() == name) {
+      bits = pin.get_bits();
+    }
+  });
+  return bits;
+}
+
+// Insert a finite range into the LNAST's bw_meta.
+static void set_bw(Lnast& ln, std::string_view name, int64_t lo, int64_t hi) {
+  BitwidthEntry e;
+  e.min                              = lo;
+  e.max                              = hi;
+  e.neg_inf                          = false;
+  e.pos_inf                          = false;
+  ln.bw_meta().ranges[std::string{name}] = e;
+}
+}  // namespace
+
+// `c = a + b` with bw_meta proving c:[0, 15]. After lowering, the Sum's
+// driver pin should carry the sbits-of-[0,15] width = 5 (sbits_for(15) = 5),
+// per apply_bw's convention.
+TEST(LnastToLgraph, LgraphSumBitsFromBwMeta) {
+  auto ln = make_add();  // top → stmts → plus(%out, $a, $b)
+  set_bw(*ln, "out", 0, 15);
+
+  auto* lg = make_lg("bw_sum");
+  ASSERT_NE(lg, nullptr);
+  Lnast_to_lgraph lowerer(lg, ln);
+  lowerer.lower();
+
+  // The bw_meta key is "out", which maps to the %out graph output. The
+  // output pin's driver is the Sum's "Y" driver — read its bits via the
+  // graph_output handle.
+  auto out_dpin = lg->get_graph_output("out").get_driver_pin();
+  EXPECT_EQ(out_dpin.get_type_op(), Ntype_op::Sum);
+  // sbits_for(15) = bit_width(15) + 1 = 5.
+  EXPECT_EQ(out_dpin.get_bits(), 5u);
+}
+
+// `out = a + b` with bw_meta proving a:[0, 255], b:[0, 15], out:[0, 511].
+// Uses add() (not pass-through) so the inputs and output don't alias the
+// same Node_pin. apply_bw should write each pin's bits independently.
+TEST(LnastToLgraph, LgraphIoBitsFromBwMeta) {
+  auto ln = make_add();  // top → stmts → plus(%out, $a, $b)
+  set_bw(*ln, "a", 0, 255);
+  set_bw(*ln, "b", 0, 15);
+  set_bw(*ln, "out", 0, 511);
+
+  auto* lg = make_lg("bw_io");
+  ASSERT_NE(lg, nullptr);
+  Lnast_to_lgraph lowerer(lg, ln);
+  lowerer.lower();
+
+  // sbits_for(255) = bit_width(255) + 1 = 9
+  // sbits_for(15)  = bit_width(15)  + 1 = 5
+  // sbits_for(511) = bit_width(511) + 1 = 10
+  EXPECT_EQ(get_input_bits(lg, "a"), 9u);
+  EXPECT_EQ(get_input_bits(lg, "b"), 5u);
+  EXPECT_EQ(get_output_bits(lg, "out"), 10u);
+}
+
+// Note: the spec's AttrGetBits/Max/Min + Wrap/SaturateNarrowing tests
+// (T3 #8 catalog) need an integration runner that exposes the per-pass
+// fold result. The runner's try_fold_ref is currently protected;
+// promoting it for tests is out of scope here. Those checks land with
+// the dedicated runner-test target when it grows up.


### PR DESCRIPTION
## Summary

Continues the LNAST bitwidth pass per `lnast_bitwidth.md`. Three
incremental commits on top of #549.

### T2 #6 — `attr_get` consults `bw_meta` first

`upass/attributes/upass_attributes_phase2.cpp` now consults
`lnast->bw_meta()` in `derive_max` / `derive_min` / `derive_bits`
before falling through to its own type/value-derived bounds. A
bitwidth-inferred range overrides a coarser type-derived bound — e.g.
`a:u8 = b & 0xF` yields `.[max] == 15` rather than `255`.

Iteration interaction: with the post-#549 pipeline order
(`attributes → constprop → bitwidth`) and default `max_iters=1`, the
first sweep's `attributes` sees an empty `bw_meta` and falls through.
The new path kicks in when `max_iters >= 2` or on a second
`pass.upass` invocation (cross-call persistence). Matches the spec.

### T2 #7 — Extract wrap/saturate math to `upass/bitwidth/wrap_sat.hpp`

Per `lnast_bitwidth.md` and the updated `attributes_spec.md` §Phase 5:
the wrap / saturate narrowing math belongs to the bitwidth pass.
`attributes` keeps policy and trigger logic; `bitwidth` owns the math.

The four pure narrowing helpers (`wrap_to_unsigned`, `wrap_to_signed`,
`saturate_unsigned`, `saturate_signed`) move from
`upass_attributes_phase5.cpp` to a new header-only target
`//upass/bitwidth:wrap_sat_hdr`. `phase5.cpp` keeps its existing call
sites and pulls the helpers in via `using` declarations.

`wrap_sat_hdr` is a hdrs-only `cc_library` (deps only on `//core`) so
`attributes` doesn't have to link the bitwidth plugin's static
registration just to call four pure Const-math helpers.

### T3 — High-value tests + apply_bw bugfix on graph-output sinks

Adds three tests:

- `BitwidthCrossInvocation.TightenAfterReseed` — verifies the
  cross-invocation persistence path: a second sweep that finds finite
  ranges in `bw_meta` reloads `range_map_` and tightens what the first
  left unbounded.
- `LnastToLgraph.LgraphSumBitsFromBwMeta` — pre-populates
  `out:[0,15]`, lowers `c = a + b`, checks the Sum's driver pin has
  5 bits.
- `LnastToLgraph.LgraphIoBitsFromBwMeta` — independent ranges on
  `a / b / out`; checks each pin's bits independently.

While writing the third test, surfaced a real bug from #549's T1 #4:
`apply_bw` was being called on the SINK view returned by
`Lgraph::add_graph_output`, but `set_bits` / `set_sign` assert
`is_driver()`. The path didn't crash in the prior tests because they
all left `bw_meta` empty. Fix: in `apply_bw`, when the target is a
graph-output sink, swap to the driver side via
`change_to_driver_from_graph_out_sink()` before writing. No-op on the
other call sites (Sum/Mux/Not drivers, graph_input return — all already
drivers).

#### Deferred from the spec's T3 test catalog

- `AttrGetBits/Max/Min` integration tests need the runner's
  `try_fold_ref` exposed for tests (currently `protected`).
- `WrapNarrowing` / `SaturateNarrowing` integration tests need
  bitwidth to consult the wrap-narrowed value from `attributes` /
  constprop's fold chain. The math is in place; the consumption
  wiring is the next follow-on.

## Test plan

- [x] `bazel test //upass/bitwidth //upass/lnast_to_lgraph //upass/attributes //upass/runner //pass/upass` — 12/12 green
- [x] `equiv_test.sh trivial` still generates Verilog with the
  post-Renau pipeline order

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/masc-ucsc/livehd/550)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Bitwidth attributes now use inferred numeric ranges when explicit values are unavailable, improving optimization accuracy.

* **Bug Fixes**
  * Fixed bitwidth and signedness application for graph output pins.

* **Tests**
  * Added bitwidth metadata verification tests and cross-invocation persistence validation.

* **Refactor**
  * Consolidated wrap/saturate narrowing utilities for improved code organization.

* **Chores**
  * Updated build dependencies.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/masc-ucsc/livehd/pull/550?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->