### PR TITLE
core-et readers: fix instance comb-cycle defer, Get_mask widening X, …

### DIFF
--- a/inou/cgen/cgen_verilog.cpp
+++ b/inou/cgen/cgen_verilog.cpp
@@ -972,6 +972,13 @@ void Cgen_verilog::process_simple_node(std::shared_ptr<File_output> fout, const 
         // through to the width-agnostic part-select forms instead.
       } else if (a_bits > 0 && range_begin >= static_cast<int>(a_bits)) {
         final_expr = absl::StrCat("{", range_end - range_begin, "{", a, "[", a_bits - 1, "]}}");
+      } else if (a_bits > 0 && range_end > static_cast<int>(a_bits) && range_begin == 0) {
+        // Pure widening: let the assignment context extend the bare net per its
+        // declared signedness (sign-extend a signed net, zero-extend unsigned).
+        // Indexing a[a_bits-1] here would overflow a net declared narrower than
+        // bits_of — an unsigned driver drops its always-0 sign bit at declare
+        // (reg [bits-2:0]), so a[bits-1] reads as undef (X) in yosys.
+        final_expr = a;
       } else if (a_bits > 0 && range_end > static_cast<int>(a_bits)) {
         auto top   = absl::StrCat("{{", range_end - a_bits, "{", a, "[", a_bits - 1, "]}}");
         final_expr = absl::StrCat(top, ",", a, "[", a_bits - 1, ":", range_begin, "]}");
@@ -1021,6 +1028,16 @@ void Cgen_verilog::process_simple_node(std::shared_ptr<File_output> fout, const 
   } else if (op == Ntype_op::SHL) {
     auto val_expr = get_expression(get_driver(find_sink_pin(node, "a")));
 
+    // Verilog `a << b` is self-determined by `a`'s width: a narrow left operand
+    // (e.g. a 1-bit const `1`, or a 1-bit signal) shifts WITHIN that narrow
+    // width and loses the high bits before the surrounding context (`~`, `&`)
+    // can widen it. That silently corrupts a dynamic bit-write RMW mask
+    // (`~(1<<idx)` for `data[idx]=…` zero-extends to all-but-low-bits instead
+    // of all-but-bit-idx). Pad the left operand to this node's full inferred
+    // width (and force unsigned) so the shift happens at the correct width.
+    auto        obits    = bits_of(node.get_driver_pin(0));
+    std::string wide_val = absl::StrCat("({", std::to_string(obits), "{1'b0}} | ", val_expr, ")");
+
     // SHL "b" is a multi-driver sink (LiveHD: all drivers represent one-hot
     // shift amounts ORed together). Walk inp_edges and filter by sink name.
     std::string onehot;
@@ -1030,7 +1047,7 @@ void Cgen_verilog::process_simple_node(std::shared_ptr<File_output> fout, const 
         continue;
       }
       auto amt_expr = get_expression(e.driver);
-      onehot        = absl::StrCat(onehot, first ? "(" : " | (", val_expr, " << ", amt_expr, ")");
+      onehot        = absl::StrCat(onehot, first ? "(" : " | (", wide_val, " << ", amt_expr, ")");
       first         = false;
     }
     final_expr = onehot;
@@ -1537,8 +1554,13 @@ void Cgen_verilog::create_locals(std::shared_ptr<File_output> fout, hhds::Graph*
           if (dpin2.out_edges().empty()) {
             continue;
           }
-          auto name2 = get_scaped_name(pin_wire_name(dpin2));
-          add_to_pin2var(fout, dpin2, name2, is_unsign(dpin2));
+          // Re-fetch the canonical driver handle (driver bit set) so this keys
+          // pin2var identically to the edge.driver a consumer's inp_edges loop
+          // uses — otherwise the same instance-output net is declared twice
+          // (once here, once by the consumer) and lookups miss this entry.
+          auto cdpin = node.create_driver_pin(dpin2.get_port_id());
+          auto name2 = get_scaped_name(pin_wire_name(cdpin));
+          add_to_pin2var(fout, cdpin, name2, is_unsign(cdpin));
         }
       }
       continue;

--- a/inou/slang/slang_context.hpp
+++ b/inou/slang/slang_context.hpp
@@ -80,6 +80,7 @@ private:
   absl::flat_hash_set<const slang::ast::Symbol*>              input_syms_;
   absl::flat_hash_set<const slang::ast::Symbol*>              output_syms_;
   absl::flat_hash_set<const slang::ast::Symbol*>              reg_syms_;   // clocked state vars
+  absl::flat_hash_set<const slang::ast::Symbol*>              latch_syms_; // level-sensitive latch state vars (subset of reg_syms_)
   absl::flat_hash_set<const slang::ast::Symbol*>              mem_syms_;   // unpacked arrays lowered as memories
   absl::flat_hash_set<const slang::ast::Symbol*>              mem_wensize_emitted_;  // memories whose wensize attr was emitted
   absl::flat_hash_set<const slang::ast::Symbol*>              declared_;   // declare stmt already emitted

--- a/inou/slang/slang_expr.cpp
+++ b/inou/slang/slang_expr.cpp
@@ -187,14 +187,18 @@ std::string Slang_context::read_symbol(const slang::ast::ValueSymbol& sym, slang
   }
 
   // Drivers emit in dataflow dependency order (lower_members), so wire reads
-  // are plain. Only the combinational-cycle fallback needs the settled-value
-  // read (delay_assign +1) - LNAST-tier only, tolg has no lowering for it.
+  // are plain. A combinational-cycle read uses a 2f-defer end-of-cycle read
+  // (attr_get .[defer]): tolg connects it to the wire's final driver as a
+  // delay-free feedback edge. This is LEC-exact, unlike the old settled read
+  // (delay_assign +1, LNAST-tier only, no tolg lowering) — important because
+  // most such "cycles" are false positives (e.g. a ready/valid handshake whose
+  // dataflow loops through a submodule instance but is not a true comb loop).
   if (in_comb_cycle_) {
     const auto* scope = sym.getParentScope();
     const bool  module_level
         = scope != nullptr && (&scope->asSymbol() == body_ || scope->asSymbol().kind == slang::ast::SymbolKind::GenerateBlock);
     if (module_level) {
-      return builder_.create_settled_read_stmts(name);
+      return builder_.create_defer_read_stmts(name);
     }
   }
 

--- a/inou/slang/slang_structure.cpp
+++ b/inou/slang/slang_structure.cpp
@@ -232,7 +232,15 @@ void Slang_context::collect_state_vars(const slang::ast::InstanceBodySymbol& bod
         }
       }
     }
-    if (!is_edge) {
+    // Latch state: an `always_latch`, or a level-sensitive (non-edge) `always`
+    // whose body uses nonblocking `<=` (the inferred-latch idiom, e.g.
+    // prim_clk_gate's `always @(clk_i or ...) if (!clk_i) en_latch <= ...`).
+    // Such vars become Ntype_op::Latch in tolg (din = cond?d:q, enable = cond);
+    // their `<=` writes are collected below. A non-edge `always` with only
+    // blocking `=` writes is plain comb (no nonblocking syms → nothing added).
+    const bool is_latch_block = pbs.procedureKind == slang::ast::ProceduralBlockKind::AlwaysLatch
+                                || (!is_edge && pbs.procedureKind == slang::ast::ProceduralBlockKind::Always);
+    if (!is_edge && !is_latch_block) {
       continue;
     }
 
@@ -240,6 +248,9 @@ void Slang_context::collect_state_vars(const slang::ast::InstanceBodySymbol& bod
     pbs.getBody().visit(wc);
     for (const auto* sym : wc.nonblocking) {
       reg_syms_.insert(sym);
+      if (is_latch_block) {
+        latch_syms_.insert(sym);
+      }
     }
   }
 }
@@ -274,6 +285,7 @@ bool Slang_context::lower_module(const slang::ast::InstanceSymbol& symbol) {
   auto saved_inputs        = std::move(input_syms_);
   auto saved_outputs       = std::move(output_syms_);
   auto saved_regs          = std::move(reg_syms_);
+  auto saved_latches       = std::move(latch_syms_);
   auto saved_mems          = std::move(mem_syms_);
   auto saved_declared      = std::move(declared_);
   auto saved_prefix        = std::move(genblk_prefix_);
@@ -292,6 +304,7 @@ bool Slang_context::lower_module(const slang::ast::InstanceSymbol& symbol) {
   input_syms_.clear();
   output_syms_.clear();
   reg_syms_.clear();
+  latch_syms_.clear();
   mem_syms_.clear();
   declared_.clear();
   genblk_prefix_.clear();
@@ -342,7 +355,8 @@ bool Slang_context::lower_module(const slang::ast::InstanceSymbol& symbol) {
   input_syms_            = std::move(saved_inputs);
   output_syms_           = std::move(saved_outputs);
   reg_syms_              = std::move(saved_regs);
-  mem_syms_              = std::move(saved_mems);
+  latch_syms_           = std::move(saved_latches);
+  mem_syms_             = std::move(saved_mems);
   declared_              = std::move(saved_declared);
   genblk_prefix_         = std::move(saved_prefix);
   module_failed_         = saved_failed;
@@ -430,9 +444,13 @@ void Slang_context::declare_reg(const slang::ast::ValueSymbol& sym) {
 
   auto ti   = tinfo(type);
   auto name = lname_of(sym);
+  // A level-sensitive latch var lowers to Ntype_op::Latch (mode "latch"); it has
+  // no clock/reset — its enable (transparency condition) and din are wired by
+  // tolg's finalize_regs from the body's if-merge.
+  const char* mode = latch_syms_.contains(&sym) ? "latch" : "reg";
   set_pending_loc(sym.location);
   builder_.create_declare_stmts(name,
-                                "reg",
+                                mode,
                                 ti.is_signed ? std::string(Dlop::get_mask_value(ti.bits - 1)->to_pyrope()) : mask_text(ti.bits),
                                 ti.is_signed ? std::string(Dlop::get_neg_mask_value(ti.bits - 1)->to_pyrope()) : "0",
                                 "nil");  // no reset by default; async patterns override via attrs
@@ -826,7 +844,11 @@ void Slang_context::lower_process(const slang::ast::ProceduralBlockSymbol& pbs) 
     case ProceduralBlockKind::Final: return;
     case ProceduralBlockKind::AlwaysComb: lower_comb_process(pbs.getBody()); return;
     case ProceduralBlockKind::AlwaysLatch:
-      emit_unsupported(pbs.location, "unsupported-latch", "always_latch is not supported by --reader slang");
+      // The latch state vars were classified in collect_state_vars (declared as
+      // mode "latch" → Ntype_op::Latch). The body lowers like any if/store; the
+      // store rebinds the latch's din/enable shadows (tolg lower_if branch-merge
+      // gives din = cond?d:q, enable = cond), exactly as for a reg.
+      lower_comb_process(pbs.getBody());
       return;
     case ProceduralBlockKind::Always:
     case ProceduralBlockKind::AlwaysFF: break;
@@ -1168,10 +1190,17 @@ Slang_context::Tinfo Slang_context::flat_or_tinfo(const slang::ast::Type& t) {
 }
 
 void Slang_context::lower_instance(const slang::ast::InstanceSymbol& inst) {
+  // lower_module() recursively lowers the callee body (lower_members), which
+  // resets in_comb_cycle_ to false on the way out. Save/restore it so that when
+  // THIS instance sits in a combinational cycle, its input port connections
+  // below still read through the 2f-defer path (a cyclic handshake's forward
+  // reference to a not-yet-lowered net must defer, not resolve to nil).
+  const bool saved_in_comb_cycle = in_comb_cycle_;
   if (!lower_module(inst)) {
     return;  // diagnosed inside
   }
-  auto callee = module_name_of(inst);
+  in_comb_cycle_ = saved_in_comb_cycle;
+  auto callee    = module_name_of(inst);
 
   proc_kind_ = Proc_kind::none;
 

--- a/inou/yosys/lgyosys_tolg.cpp
+++ b/inou/yosys/lgyosys_tolg.cpp
@@ -398,15 +398,23 @@ static hhds::Pin_class create_pick_operator(hhds::Graph* g, const RTLIL::Wire* w
   if (auto it = partially_assigned.find(wire); it != partially_assigned.end()) {
     const auto it_bits = partially_assigned_bits.find(wire);
     I(it_bits != partially_assigned_bits.end());
+    // Both vectors are sized to wire->width and indexed by BIT-OFFSET (a segment
+    // starting at bit `o` stores its pin at index `o`, in-between indices empty)
+    // — the same convention the materializer process_partially_assigned_other
+    // uses (`it.second[i]`, `i += width`). The loop locates the segment whose
+    // start equals `offset` by accumulating widths in `bits`; the pin is then at
+    // index `bits` (== offset). The old code returned `it->second[pos]` with a
+    // DENSE counter `pos` that diverges from the bit-offset after the first
+    // segment, so every non-zero-offset slice returned an empty pin — the
+    // read-all-entries + dynamic-index register-file pattern collapsed to
+    // const 0 / all-x.
     int32_t bits = 0;
-    auto    pos  = 0u;
     for (const auto& b : it_bits->second) {
       if (bits == offset) {
-        I(it->second.size() > pos);
-        return it->second[pos];
+        I(it->second.size() > static_cast<size_t>(bits));
+        return it->second[bits];
       }
       bits += b;
-      ++pos;
     }
   }
 

--- a/inou/yosys/tests/nshift.v
+++ b/inou/yosys/tests/nshift.v
@@ -1,0 +1,14 @@
+
+// Shift by a negative *constant* count. Verilog shift amounts are unsigned, so
+// a narrow negative literal masks to its unsigned bit pattern (e.g. 3'sb111 is
+// -1, used as the count it is 7). The slang reader must produce that defined
+// result, not nil/error, and match yosys for LEC.
+
+module nshift (input [7:0] a, output [7:0] b, output [7:0] c, output [7:0] d, output [7:0] e);
+
+assign b = a >> 3'sb111;            // count masks to 7
+assign c = a << 3'sb110;            // count masks to 6
+assign d = a >>> 3'sb101;           // logical (a unsigned), count 5
+assign e = $signed(a) >>> 3'sb100;  // arithmetic, count 4
+
+endmodule

--- a/lnast/lnast_builder.cpp
+++ b/lnast/lnast_builder.cpp
@@ -376,6 +376,23 @@ std::string Lnast_builder::create_settled_read_stmts(std::string_view var) {
   return tmp_var;
 }
 
+// 2f-defer — an end-of-cycle (deferred) read: `tmp = var.[defer]`. tolg lowers
+// it to a passthrough buffer whose input is connected, after all statements are
+// lowered (resolve_defers), to `var`'s final driver. Unlike the settled read
+// (delay_assign +1, LNAST-tier only, no tolg lowering → not LEC-exact), this is
+// a real, delay-free combinational feedback edge — the correct lowering for a
+// combinational-cycle read (e.g. a ready/valid handshake whose dataflow loops
+// through a submodule instance but is not a true combinational loop).
+std::string Lnast_builder::create_defer_read_stmts(std::string_view var) {
+  I(!var.empty());
+  auto idx     = lnast->add_child(idx_stmts, Lnast_ntype::create_attr_get());
+  auto tmp_var = create_lnast_tmp();
+  add_ref_child(idx, tmp_var);
+  add_ref_child(idx, var);
+  add_const_child(idx, "defer");
+  return tmp_var;
+}
+
 void Lnast_builder::create_declare_stmts(std::string_view var, std::string_view mode, std::string_view max_txt,
                                          std::string_view min_txt, std::string_view init) {
   I(!var.empty() && !mode.empty());

--- a/lnast/lnast_builder.hpp
+++ b/lnast/lnast_builder.hpp
@@ -137,6 +137,10 @@ public:
   // Settled-value read of a concurrently-driven wire: delay_assign(tmp, var, 1)
   // (offset +1 = "future/settled this cycle"). Returns the tmp.
   std::string create_settled_read_stmts(std::string_view var);
+  // 2f-defer end-of-cycle read: attr_get(tmp, var, "defer"). A delay-free
+  // combinational feedback edge (tolg connects it to var's final driver). The
+  // LEC-exact replacement for the settled read in a combinational cycle.
+  std::string create_defer_read_stmts(std::string_view var);
 
   // declare( ref(var), type, const(mode), [init] ). Empty max/min = the
   // prim_type_none sentinel; empty init = no init child (a reg without a

--- a/pass/cprop/cprop.cpp
+++ b/pass/cprop/cprop.cpp
@@ -679,7 +679,12 @@ void Cprop::scalar_sext(hhds::Node_class& node, std::vector<hhds::Edge_class>& i
 
   const auto& wire_dpin = inp_edges_ordered[0].driver;
 
-  if (self_pos == 1) {
+  // Sext(X,1) feeding a Mux can be bypassed (a Mux selector/arm is contractually
+  // 1 bit) ONLY when X is already 1 bit. For a wider X (e.g. the offset-0 select
+  // of a bmux mux-tree, where X is the full ~addr signal) bypassing connects a
+  // multi-bit value to the 1-bit Mux selector, which cgen then emits as a
+  // reduction-OR (`if (x)` instead of `if (x[0])`) — selecting the wrong arm.
+  if (self_pos == 1 && bits_of(wire_dpin) == 1) {
     for (auto& e : node.out_edges()) {
       if (type_op_of(e.sink.get_master_node()) == Ntype_op::Mux) {
         e.sink.connect_driver(wire_dpin);

--- a/upass/runner/upass_runner.cpp
+++ b/upass/runner/upass_runner.cpp
@@ -4517,6 +4517,9 @@ void uPass_runner::unroll_while() {
 
   // 2f-nil_diag — a condition that folds to nil is an illegal use of nil; a
   // genuinely runtime condition folds to nullopt (not nil) and stays verbatim.
+  // An uncertainty-pinned poison nil (conditionally-driven var) is treated as
+  // UNKNOWN, not an error (see the if-condition note above); a `const c = nil`
+  // clears the uncertain mark on store, so it still errors.
   if (cval && !cval->is_invalid() && cval->is_nil()) {
     report_cond_nil("while");
     return;

--- a/upass/tolg/upass_tolg.cpp
+++ b/upass/tolg/upass_tolg.cpp
@@ -697,17 +697,48 @@ private:
       }
       setup_sink_by_name(flop, "din").connect_driver(din);
 
+      if (info.is_latch) {
+        // A latch (Ntype_op::Latch) has no clock/reset/posclk: wire only its
+        // enable (the transparency condition; cgen process_latch emits
+        // `always @* if(enable) q = din`). din already carries the if-merge
+        // `cond ? d : q`. Skip the const-false (never-written) enable.
+        if (info.decl_mw == 0) {
+          auto    dit = mw_map_.find(din_key(name));
+          int32_t mw  = dit != mw_map_.end() ? dit->second : int32_t{1};
+          set_bits(q, mw + 1);
+          set_unsign(q);
+          mw_map_[name] = mw;
+        }
+        if (auto eit = pin_map_.find(en_key(name)); eit != pin_map_.end()) {
+          const auto  en       = eit->second;
+          const auto  en_nid   = en.get_master_node().get_debug_nid();
+          const bool  is_false = en_false_valid_ && en_nid == en_false_pin_.get_master_node().get_debug_nid();
+          if (!is_false) {
+            setup_sink_by_name(flop, "enable").connect_driver(en);
+          }
+        }
+        continue;
+      }
+
       // clock: explicit clock_pin=NAME beats the implicit/shared clock input.
+      // A named clock is usually a module input (clk_i), but can also be an
+      // internal/derived wire — e.g. a gated clock (a clock-gate cell's
+      // `clk & en_latch` output) feeding a flop. Check has_input FIRST (a clock
+      // input is NOT in pin_map_; an unrelated same-named signal might be, which
+      // is why pin_map_-first is wrong), then fall back to pin_map_ for the
+      // internal-wire case. get_input_pin would assert on a non-input.
       if (!info.clock_pin_name.empty()) {
-        auto cpin = g_->get_input_pin(info.clock_pin_name);
-        if (cpin.is_invalid()) {
-          error_here("upass.tolg: reg '{}' names clock_pin '{}' but '{}' has no such input",
+        if (g_->get_io()->has_input(info.clock_pin_name)) {
+          setup_sink_by_name(flop, "clock_pin").connect_driver(g_->get_input_pin(info.clock_pin_name));
+        } else if (auto cn = std::string(info.clock_pin_name); pin_map_.contains(cn)) {
+          setup_sink_by_name(flop, "clock_pin").connect_driver(pin_map_.at(cn));
+        } else {
+          error_here("upass.tolg: reg '{}' names clock_pin '{}' but '{}' has no such input/wire",
                      name,
                      info.clock_pin_name,
                      lnast_->get_top_module_name());
           continue;
         }
-        setup_sink_by_name(flop, "clock_pin").connect_driver(cpin);
       } else if (!clock_name_.empty()) {
         setup_sink_by_name(flop, "clock_pin").connect_driver(clock_pin());
       } else {
@@ -912,13 +943,14 @@ private:
     // memory; a mut/const array that survived to tolg (runtime-indexed) → a
     // comb type=2 array / ROM. Never a Flop, never a plain binding.
     const bool is_reg   = mode == "reg" || mode.starts_with("reg ");
+    const bool is_latch = mode == "latch";  // level-sensitive latch (din+enable, no clock)
     if (!type_nid.is_invalid() && Lnast_ntype::is_comp_type_array(lnast_->get_type(type_nid))
         && (is_reg || mode == "mut" || mode == "const" || mode.starts_with("mut ") || mode.starts_with("const "))) {
       lower_mem_declare(name_nid, type_nid, mode_nid, /*is_array=*/!is_reg);
       return;
     }
 
-    if (!is_reg) {
+    if (!is_reg && !is_latch) {
       // mut/const/type declares carry no graph payload here (values arrive
       // via their stores); nothing to lower.
       return;
@@ -952,14 +984,16 @@ private:
     // din/enable keys, finalize_regs() wires the pins. The declared type
     // gives q's width up front (a counter's `r + 1` read needs it before any
     // din store); untyped regs restamp from the final din width.
-    auto flop = make_node(Ntype_op::Flop);
+    auto flop = make_node(is_latch ? Ntype_op::Latch : Ntype_op::Flop);
     // clock wiring happens in finalize_regs (a clock_pin/posclk attr_set may
-    // arrive after the declare).
+    // arrive after the declare). A latch has no clock/reset — finalize_regs
+    // wires only its din + enable.
     auto name = lnast_->get_name(name_nid);
     auto q    = flop.create_driver_pin(0);
 
     Reg_info info;
     info.flop     = flop;
+    info.is_latch = is_latch;
     info.decl_nid = nid;
     if (!type_nid.is_invalid()) {
       std::tie(info.decl_mw, info.is_signed) = declared_width(type_nid);
@@ -1018,6 +1052,7 @@ private:
     bool             sync_val = true;
     bool             negreset = false;
     std::string      initial_txt;  // explicit initial=N (overrides init_txt)
+    bool             is_latch = false;  // mode "latch": Ntype_op::Latch, wire din+enable only
   };
 
   // Shadow pin_map_ keys for a reg's next-state value and write-enable. The


### PR DESCRIPTION
…cgen dups

Takes ../core-et/fpga from 1 to 3 full-bar projects (both --reader slang and --reader yosys-slang compile + pass lgcheck/LEC): fifo_example, test_clk_prims, ulx3s_uart_bringup. Full regression green (682/682).

Key fixes:
- slang reader (lower_instance): save/restore in_comb_cycle_ across lower_module(). lower_module recursively lowers the callee body, which resets the flag to false; the instance's own input ports were then lowered with the flag clobbered, so a cyclic handshake's forward reference (e.g. fifo.rready_i <- tx_pop_ready <- u_tx.ready_o) resolved to nil(0sb?) instead of a 2f-defer. This was the root of the instance comb-cycle false-positive.
- cgen Get_mask: a constant widening of a net declared narrower than bits_of (an unsigned driver drops its always-0 sign bit at declare, reg [bits-2:0]) indexed the missing top bit -> yosys reads undef (X), which the SAT miter exploited (prim_fifo_sync sum_216[7] on a reg [6:0]). For a pure widening, emit the bare net and let the assignment context extend per declared sign.
- cgen create_locals: a Sub-output net was declared twice (producer out_pins() vs consumer inp_edges used different pin handles -> distinct class_index keys, no dedup), breaking iverilog. Re-fetch the canonical driver handle to key.
- inou/yosys/tests/nshift.v: add the missing test for the "nshift":"lec" ladder entry (negative-constant shift count masks to unsigned).

Also folds in earlier accumulated reader/tolg/cgen fixes verified in this work (latch lowering, memory clock_pin/dout, dynamic-index pick, .[defer] read).

check list
* Read the [policy](CONTRIBUTING.md) for the instructions on contributions
* Make sure that the license is BSD-3, MIT, Apache, or similar. Even thought it is not Apache, there should be NO patents in the code
* Add yourself to [credits](CREDITS.txt) if you have a new contribution
* It is recommended to contact a [code owner](CODE_OWNERS.txt) if you are planning a large contribution
* Follow the [github/lgraph](GitHub-use.md) instructions to create a pull request
* Create a meaningful commit log
* In case of conflict, check the [code of conduct](CODE_OF_CONDUCT.md)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for level-sensitive latch processes in hardware designs.
  * Introduced deferred-read handling for improved combinational cycle behavior.

* **Bug Fixes**
  * Fixed mask widening and left-shift operations to prevent value corruption.
  * Corrected bit indexing in partially-assigned wire handling.
  * Improved shift operation handling with proper operand width management.
  * Fixed multi-driver output declaration handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/masc-ucsc/livehd/565)
<!-- Reviewable:end -->
